### PR TITLE
Add Units to Table Values

### DIFF
--- a/src/components/BuildingsTable.vue
+++ b/src/components/BuildingsTable.vue
@@ -35,13 +35,13 @@ export default class BuildingsTable extends Vue {
 
 <template>
   <div class="table-cont">
-    <table :class="{ '-with-sq-footage': showSquareFootage }">
+    <table :class="{ '-wide': showSquareFootage || showGasUse || showElectricityUse }">
       <thead>
         <tr>
           <th scope="col">
             Property Name / address
           </th>
-          <th scope="col">
+          <th scope="col" class="prop-type">
             Primary Property Type
           </th>
           <th v-if="showSquareFootage">
@@ -50,32 +50,32 @@ export default class BuildingsTable extends Vue {
           <th
             v-if="showGasUse"
             scope="col"
-            class="numeric"
+            class="numeric wide-col"
           >
             Natural Gas Use<br>
-            (kBtu)
+            <span class="unit">(kBtu)</span>
           </th>
           <th
             v-if="showElectricityUse"
             scope="col"
-            class="numeric"
+            class="numeric wide-col"
           >
             Electricity Use<br>
-            (kBtu)
+            <span class="unit">(kBtu)</span>
           </th>
           <th
             scope="col"
-            class="numeric emissions-int"
+            class="numeric wide-col"
           >
             Greenhouse Gas Intensity<br>
-            (kg CO<sub>2</sub>/sqft)
+            <span class="unit">(kg CO<sub>2</sub> eq./sqft)</span>
           </th>
           <th
             scope="col"
-            class="numeric emissions"
+            class="numeric wide-col"
           >
             Total Greenhouse Emissions<br>
-            (metric tons CO<sub>2</sub> eq.)
+            <span class="unit">(metric tons CO<sub>2</sub> eq.)</span>
           </th>
         </tr>
       </thead>
@@ -113,6 +113,7 @@ export default class BuildingsTable extends Vue {
                 :building="edge.node"
                 :should-round="true"
                 :stats="BuildingBenchmarkStats"
+                :unit="'sqft'"
                 stat-key="GrossFloorArea"
               />
             </template>
@@ -130,6 +131,7 @@ export default class BuildingsTable extends Vue {
                 :building="edge.node"
                 :should-round="true"
                 :stats="BuildingBenchmarkStats"
+                :unit="'kBtu'"
                 stat-key="NaturalGasUse"
               />
             </template>
@@ -146,6 +148,7 @@ export default class BuildingsTable extends Vue {
                 :building="edge.node"
                 :should-round="true"
                 :stats="BuildingBenchmarkStats"
+                :unit="'kBtu'"
                 stat-key="ElectricityUse"
               />
             </template>
@@ -161,6 +164,7 @@ export default class BuildingsTable extends Vue {
                 :building="edge.node"
                 :stats="BuildingBenchmarkStats"
                 stat-key="GHGIntensity"
+                :unit="'kg/sqft'"
               />
             </template>
             <template v-else>
@@ -174,6 +178,7 @@ export default class BuildingsTable extends Vue {
                 :should-round="true"
                 :stats="BuildingBenchmarkStats"
                 stat-key="TotalGHGEmissions"
+                :unit="'tons'"
               />
             </template>
             <template v-else>
@@ -202,14 +207,17 @@ export default class BuildingsTable extends Vue {
     min-width: 60rem;
     border-collapse: collapse;
 
-    // Increase width if showing square footage (biggest buildings page)
-    &.-with-sq-footage {
-      min-width: 80rem;
+    // Increase width if showing extra columns on specific pages
+    &.-wide {
+      min-width: 88rem;
+
+      // Wide columns shouldn't be as wide if we have more of them
+      .wide-col { width: 17%; }
     }
 
     a {
       font-weight: bold;
-      font-size: 1.25em;
+      font-size: 1.125em;
       text-decoration: none;
       white-space: nowrap;
     }
@@ -222,10 +230,15 @@ export default class BuildingsTable extends Vue {
 
       th {
         text-align: left;
-        font-weight: bold;
-        line-height: 1.5;
-        padding-top: 0.5rem;
-        padding-bottom: 0.5rem;
+        font-weight: 500;
+        line-height: 1.25;
+        padding-top: 0.75rem;
+        padding-bottom: 0.75rem;
+
+        .unit {
+          font-size: smaller;
+          font-weight: normal;
+        }
       }
     }
 
@@ -236,7 +249,8 @@ export default class BuildingsTable extends Vue {
       &:first-of-type { padding-left: 1rem; }
       &:last-of-type { padding-right: 1rem; }
       &.numeric { text-align: right; }
-      &.emissions, &.emissions-int { width: 20%; }
+      &.wide-col { width: 20%; }
+      &.prop-type { width: 12rem; }
     }
 
     tr:nth-of-type(2n + 2) { background-color: $grey; }

--- a/src/components/OverallRankEmoji.vue
+++ b/src/components/OverallRankEmoji.vue
@@ -5,7 +5,7 @@
   >
     <span
       v-if="overallRank"
-      class="overall-rank-emoji"
+      class="emoji overall-rank-emoji"
       :title="overallRank.msg"
     >
       {{ overallRank.emoji }}
@@ -14,8 +14,8 @@
     <!-- Show image emoji on tables -->
     <span
       v-if="hasBuildingImg && !largeView"
-      class="has-img-emoji"
-      title="Has Image"
+      class="emoji has-img-emoji"
+      title="Has building photograph"
     >
       📷
     </span>
@@ -55,8 +55,9 @@ export default class OverallRankEmoji extends Vue {
   display: inline;
   white-space: nowrap;
 
-  .overall-rank-emoji, .has-img-emoji {
+  .emoji {
     vertical-align: 0.2em;
+    cursor: help;
   }
 
   .overall-rank-emoji { font-size: 0.925em; }

--- a/src/components/RankText.vue
+++ b/src/components/RankText.vue
@@ -3,6 +3,7 @@
     <div class="stat-value">
       <span v-if="shouldRound">{{ Math.round(statValue).toLocaleString() }}</span>
       <span v-else>{{ statValue.toFixed(1) }}</span>
+      <span v-if="unit" class="unit" v-html="' ' + unit"></span>
 
       <!-- Show icons for below or above average if we have an average for this stat -->
       <template v-if="stats[statKey]">
@@ -64,9 +65,14 @@ import { RankConfig, IBuilding, IBuildingBenchmarkStats } from '~/common-functio
 @Component
 export default class RankText extends Vue {
   @Prop({required: true}) building!: IBuilding;
+
   @Prop({required: true}) statKey!: string;
+
   @Prop({required: true}) stats!: IBuildingBenchmarkStats;
+
   @Prop({default: false}) shouldRound!: boolean;
+
+  @Prop() unit?: string;
 
   // Expose RankConfig to template
   RankConfig = RankConfig;
@@ -128,6 +134,8 @@ export default class RankText extends Vue {
 .rank-text {
   .stat-value {
     white-space: nowrap;
+
+    .unit { font-size: smaller; }
 
     img {
       width: 1.25em;

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -166,7 +166,7 @@ query ($id: ID!) {
               :building="$page.building"
               :stat-key="'GHGIntensity'"
               :stats="BuildingBenchmarkStats"
-              :unit="'kg CO<sub>2</sub> / sqft'"
+              :unit="'kg CO<sub>2</sub>e / sqft'"
             />
           </dd>
         </div>

--- a/src/templates/BuildingOwner.vue
+++ b/src/templates/BuildingOwner.vue
@@ -178,7 +178,7 @@ export default class BiggestBuildings extends Vue {
         <li>
           <strong>
             Average GHG Intensity:
-            {{ avgGHGIntensity }} kg CO<sub>2</sub>/sqft
+            {{ avgGHGIntensity }} kg CO<sub>2</sub>e/sqft
           </strong>
 
           <p class="footnote">


### PR DESCRIPTION
Add units to the tables to make the number values more impactful, like they are on the details pages:

| Before | After |
| --- | --- |
| ![Screenshot from 2023-03-29 20-06-48](https://user-images.githubusercontent.com/3187531/228701818-c1be43ce-1af2-4d2b-a55e-d1c490ee1b21.png) | 
![Screenshot from 2023-03-29 20-06-54](https://user-images.githubusercontent.com/3187531/228701817-7342985e-1c54-43b5-a5b5-32f0bcb0c895.png) |

Also tweaked the emoji language a bit and gave them a help cursor.