### PR TITLE
Add new /building-id/:ID route

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -38,9 +38,10 @@ module.exports = {
         component: './src/templates/BuildingDetails.vue',
       },
       {
-        name: 'building-by-id',
+        // A path that redirects from a building ID to the canonical slug URL
+        name: 'building-id-redirect',
         path: '/building-id/:ID',
-        component: './src/templates/BuildingDetails.vue',
+        component: './src/templates/BuildingIDRedirect.vue',
       },
     ],
   },

--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -37,6 +37,11 @@ module.exports = {
         path: '/building/:slugSource',
         component: './src/templates/BuildingDetails.vue',
       },
+      {
+        name: 'building-by-id',
+        path: '/building-id/:ID',
+        component: './src/templates/BuildingDetails.vue',
+      },
     ],
   },
 

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -2,6 +2,7 @@
 query ($id: ID!) {
   building(id: $id) {
     slugSource
+    ID
     Address
     ChicagoEnergyRating
     CommunityArea
@@ -74,6 +75,10 @@ query ($id: ID!) {
               Find on Google Maps <NewTabIcon />
             </a>
           </div>
+
+          <p class="building-id">
+            Chicago Building ID: {{ $page.building.ID }}
+          </p>
         </div>
 
         <BuildingImage :building="$page.building" />
@@ -440,17 +445,20 @@ export default class BuildingDetails  extends Vue {
     }
   }
 
-
   h1 { margin: 0; }
 
   .address {
     font-size: 1.25rem;
-    margin-bottom: 1rem;
 
     .google-maps-link {
       font-size: 0.825rem;
       margin-left: 0.5rem;
     }
+  }
+
+  .building-id {
+    font-size: 0.75rem;
+    margin-top: 0;;
   }
 
   .building-details {

--- a/src/templates/BuildingIDRedirect.vue
+++ b/src/templates/BuildingIDRedirect.vue
@@ -1,0 +1,27 @@
+<template>
+  <div><!-- No content, redirect page --></div>
+</template>
+
+<script>
+export default {
+  metaInfo() {
+    return {
+        title: `Redirecting to ${this.$page.building.path}`,
+        meta: [
+            { 'http-equiv': 'refresh', content: `0; URL=${this.$page.building.path}`},
+        ],
+        link: [
+            { rel: 'canonical', href: `https://electrifychicago.net/${this.$page.building.path}` },
+        ],
+    };
+  },
+};
+</script>
+
+<page-query>
+query ($id: ID!) {
+  building(id: $id) {
+    path
+  }
+}
+</page-query>


### PR DESCRIPTION
Adds a new `/buidling-id/:ID` route that can pull up a building based solely by its building ID and then redirects to the appropriate page:

https://github.com/vkoves/electrify-chicago/assets/3187531/fc8682e8-a1bc-47e8-a39d-4ba5efd8bf1b