### PR TITLE
Improve category rankings

### DIFF
--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -72,12 +72,12 @@
         <!-- If stat rank is < 50%, invert it.
         E.g higher than of benchmarked buildings becomes less than 99% of buildings-->
         <template v-if="statRankPercent > 50">
-          Higher than {{ statRankPercent }}% of others
+          Higher than {{ statRankPercent }}% of all buildings
         </template>
         <!-- Only show lower than X% if not getting a trophy-->
         <template v-else-if="statRankInverted > RankConfig.TrophyRankInvertedMax">
           <!-- Never show lower than 100%, top out at 100%-->
-          Lower than {{ Math.min(99, 100 - statRankPercent) }}% of others
+          Lower than {{ Math.min(99, 100 - statRankPercent) }}% of all buildings
         </template>
       </div>
 
@@ -95,7 +95,7 @@
         v-if="stats[statKey]"
         class="median"
       >
-        Median benchmarked building*: <br>
+        Median Chicago building*: <br>
         <div class="median-val">
           {{ stats[statKey].median.toLocaleString() }} <span v-html="unit" />
         </div>
@@ -105,7 +105,7 @@
         v-if="BuildingStatsByPropertyType[propertyType][statKey]"
         class="median"
       >
-        Median benchmarked {{ propertyType }}*: <br>
+        Median {{ propertyType }}*: <br>
         <div class="median-val">
           {{ BuildingStatsByPropertyType[propertyType][statKey].median.toLocaleString() }}
           <span v-html="unit" />

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -59,7 +59,7 @@
       <!-- If in the lowest 30, show that unless square footage (TODO: Move to GreatRankMax) -->
       <div
         v-if="!isSquareFootage && propertyStatRankInverted"
-        class="rank"
+        class="property-rank"
       >
         #{{ propertyStatRankInverted }} Lowest of {{ pluralismForPropertyType }} 🏆
       </div>
@@ -85,30 +85,22 @@
         v-if="medianMultipleMsgCityWide"
         class="median-comparison"
       >
-        <span class="val">{{ medianMultipleMsgCityWide }}</span> the median,
+        <div>
+          <span class="val">{{ medianMultipleMsgCityWide }} median</span>
 
-        <span class="val">{{ medianMultiplePropertyType }}</span> the median {{ propertyType }}
-      </div>
-
-
-      <div
-        v-if="stats[statKey]"
-        class="median"
-      >
-        Median Chicago building*: <br>
-        <div class="median-val">
-          {{ stats[statKey].median.toLocaleString() }} <span v-html="unit" />
+          <div class="median-val">
+            {{ stats[statKey].median.toLocaleString() }}
+            <span v-html="unit" />
+          </div>
         </div>
-      </div>
 
-      <div
-        v-if="BuildingStatsByPropertyType[propertyType][statKey]"
-        class="median"
-      >
-        Median {{ propertyType }}*: <br>
-        <div class="median-val">
-          {{ BuildingStatsByPropertyType[propertyType][statKey].median.toLocaleString() }}
-          <span v-html="unit" />
+        <div v-if="medianMultiplePropertyType">
+          <span class="val">{{ medianMultiplePropertyType }} median {{ propertyType }}</span>
+
+          <div class="median-val">
+            {{ BuildingStatsByPropertyType[propertyType][statKey].median.toLocaleString() }}
+            <span v-html="unit" />
+          </div>
         </div>
       </div>
     </template>
@@ -436,25 +428,23 @@ export default class StatTile extends Vue {
   // Apply a semi-bold to rank
   .rank { font-weight: 500; }
 
+  .property-rank { font-size: small; }
+
   .median-comparison {
-    font-size: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
 
     .val {
-      font-size: 0.875rem;
-      font-weight: bold;
+      font-size: large;
+      font-weight: 500;
     }
+
+    .median-val { font-size: small; }
   }
 
   .median, .percentile { font-size: 0.75rem; }
-
-  .median {
-    margin-top: 0.5rem;
-
-    .median-val {
-      font-weight: 500;
-      font-size: larger;
-    }
-  }
 
   .percentile {
     font-weight: normal;

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -282,6 +282,8 @@ export default class StatTile extends Vue {
       6: 2,
       9: 3,
       20: 5,
+      50: 10,
+      80: 15,
     };
 
     let amountToRank = 0;
@@ -300,8 +302,6 @@ export default class StatTile extends Vue {
    */
   get propertyStatRank(): number | null {
     const statRank = this.building[this.statKey + 'RankByPropertyType'] as string;
-
-    console.log('propertiesToAwardThisType', this.propertiesToAwardThisType);
 
     if (statRank && parseFloat(statRank) <= this.propertiesToAwardThisType) {
       return Math.round(parseFloat(statRank));
@@ -323,8 +323,6 @@ export default class StatTile extends Vue {
       const statRankNum = Math.round(parseFloat(statRank));
       // Rank 100/100 should invert to #1 lowest, not #0
       const rankInverted =  numBuildingsOfType - statRankNum + 1;
-
-      console.log({ rankInverted });
 
       // Only return the inverted rank if it's bad enough for this category
       return rankInverted <= this.propertiesToAwardThisType ? rankInverted : null;

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -176,6 +176,9 @@ query ($id: ID!) {
       </div>
 
       <h2>Emissions & Energy Information</h2>
+      <p class="year-note">
+        For {{ DataYear }}
+      </p>
 
       <dl class="emission-stats">
         <div>
@@ -280,7 +283,7 @@ query ($id: ID!) {
       <p class="constrained">
         <strong>* Important Note:</strong> Rankings and medians are among <em>included</em>
         buildings, which are those who reported under the Chicago Energy Benchmarking Ordinance for
-        the year 2020 with emissions greater than 1,000 metric tons.
+        the year {{ DataYear }} with emissions greater than 1,000 metric tons.
       </p>
 
       <p class="footnote">
@@ -420,6 +423,8 @@ export default class BuildingDetails  extends Vue {
   /** Expose stats to readme */
   readonly BuildingBenchmarkStats: IBuildingBenchmarkStats = BuildingBenchmarkStats;
 
+  readonly DataYear: number = 2020;
+
    /** Set by Gridsome to results of GraphQL query */
   $page: any;
 
@@ -527,7 +532,12 @@ export default class BuildingDetails  extends Vue {
 
   h1 { margin: 0; }
 
-  h2 { margin: 2.5rem 0 0.5rem 0; }
+  h2 { margin: 2.5rem 0 0; }
+
+  p.year-note {
+    font-size: 0.825rem;
+    margin-top: 0;
+  }
 
   .address {
     font-size: 1.25rem;


### PR DESCRIPTION
Improved category rankings (e.g. #1 highest of K-12, #5 lowest of Condos) by making the number of awards (good or bad) we give out be tied to the size of the category, so we don't say #3 worst of a category of 3 buildings, for example.

I also improved the layout of the median information so that the multiplier (e.g. 3x the median) is larger than the actual median, since that's context information and not unique to the building. Here's a comparison with Marina towers:

| Before | After |
| --- | --- |
| ![Screenshot from 2023-06-21 00-21-12](https://github.com/vkoves/electrify-chicago/assets/3187531/ba12b290-d47f-4478-9269-e2e85b433b57) | ![Screenshot from 2023-06-21 00-20-58](https://github.com/vkoves/electrify-chicago/assets/3187531/deda2d56-879c-4992-9cf0-61be5fea0776) |

Resolves #34 