### PR TITLE
Add Electric & Gas Bill Estimates to Building Details

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Fixes # (issue)
 
 # Testing Instructions
 
-Please describe the tests/QA that you did to verify your changes. Provide instructions so we can reproduce. 
+Please describe the tests/QA that you did to verify your changes. Provide instructions so we can reproduce.
 Please also list any relevant details for your test configuration
 
 # Checklist:
@@ -14,10 +14,7 @@ Please also list any relevant details for your test configuration
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
 
 <!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -186,14 +186,14 @@ export function getOverallRankEmoji(
 }
 
 /**
- * A constant for Chicago avg. utility costs in the latest data year, which we use to estimate an
- * upper bound of how much a building would pay for gas and electric
+ * A constant for Chicago avg. utility costs in the latest data year (in dollar per unit of energy),
+ * which we use to estimate an upper bound of how much a building would pay for gas or electric
  */
 export const UtilityCosts = {
   year: 2021,
   source: 'https://www.bls.gov/regions/midwest/news-release/AverageEnergyPrices_Chicago.htm',
-  electricCostPerKWh: 0.147,
-  gasCostPerTherm: 1.101,
+  electricCostPerKWh: 0.143,
+  gasCostPerTherm: 1.192,
 };
 
 /**

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -184,4 +184,31 @@ export function getOverallRankEmoji(
 
   return null;
 }
+
+export const UtilityCosts = {
+  year: 2021,
+  source: 'https://www.bls.gov/regions/midwest/news-release/AverageEnergyPrices_Chicago.htm',
+  electricCostPerKWh: 0.147,
+  gasCostPerTherm: 1.101,
+};
+
+/**
+ * Given an amount of natural gas or electricity used by a building, returns a cost
+ * estimate of how much a building would have spent at average retail prices for
+ * that energy.
+ */
+export function estimateUtilitySpend(energyUseKbtu: number, isElectric: boolean): number {
+  const kwhToKbtuMult = 3.412; // 1kWh = 3.412 kBtu
+  const thermToKbtuMult = 99.976; // 1th = 99.976 kBtu
+
+  const costPerKbtuNatGas = UtilityCosts.gasCostPerTherm / thermToKbtuMult;
+  const costPerKbtuElectric = UtilityCosts.electricCostPerKWh / kwhToKbtuMult;
+
+  const costPerKbtu = isElectric ? costPerKbtuElectric : costPerKbtuNatGas;
+
+  return costPerKbtu * energyUseKbtu;
+
+  // Keating nat gas cost: $708,860.13
+  // Keating electric cost: $82,898.53026
+}
 </script>

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -32,8 +32,9 @@
         </template>
       </div>
 
-      <div v-if="costEstimate">
-        Estimated Cost: ${{ Math.round(costEstimate).toLocaleString() }}
+      <div v-if="costEstimate" class="bill-estimate">
+        <strong>Est. {{ statKey === 'NaturalGasUse' ? 'Gas' : 'Electric' }} Bill:</strong>
+        ${{ Math.round(costEstimate).toLocaleString() }} **
       </div>
 
       <!-- Only show the rank if in the top 50, #102th highest _ doesn't mean much -->
@@ -188,7 +189,7 @@ import {
   IBuilding,
   IBuildingBenchmarkStats,
   RankConfig,
-} from '~/common-functions.vue';
+} from '../common-functions.vue';
 
 /**
  * A group of all the core stats by property type (e.g. GHG intensity median)
@@ -535,6 +536,8 @@ export default class StatTile extends Vue {
   .rank { font-weight: 500; }
 
   .property-rank { font-size: small; }
+
+  .bill-estimate { margin-bottom: 0.25rem; }
 
   .median-comparison {
     display: flex;

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -32,7 +32,10 @@
         </template>
       </div>
 
-      <div v-if="costEstimate" class="bill-estimate">
+      <div
+        v-if="costEstimate"
+        class="bill-estimate"
+      >
         <strong>Est. {{ statKey === 'NaturalGasUse' ? 'Gas' : 'Electric' }} Bill:</strong>
         ${{ Math.round(costEstimate).toLocaleString() }} for {{ building.DataYear }}**
       </div>

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -190,6 +190,9 @@ import {
   RankConfig,
 } from '~/common-functions.vue';
 
+/**
+ * A group of all the core stats by property type (e.g. GHG intensity median)
+ */
 export interface PropertyByBuildingStats
 {
   [propertyType: string]: IBuildingBenchmarkStats;
@@ -201,7 +204,7 @@ export interface PropertyByBuildingStats
   */
 @Component
 export default class StatTile extends Vue {
-  readonly BuildingStatsByPropertyType:PropertyByBuildingStats = buildingStatsByPropertyType;
+  readonly BuildingStatsByPropertyType: PropertyByBuildingStats = buildingStatsByPropertyType;
 
   @Prop({required: true}) building!: IBuilding;
   @Prop({required: true}) statKey!: string;
@@ -353,11 +356,14 @@ export default class StatTile extends Vue {
   }
 
   get propertiesToAwardThisType(): number {
-    const properStatBlock = this.BuildingStatsByPropertyType[this.propertyType];
-    if (!properStatBlock) {
+    // The stats for buildings of this building's type
+    const propertyStats = this.BuildingStatsByPropertyType[this.propertyType];
+
+    if (!propertyStats) {
       return 0;
     }
-    const numBuildingsOfType = properStatBlock[this.statKey]?.count;
+
+    const numBuildingsOfType = propertyStats[this.statKey]?.count;
 
     /**
      * The amount of buildings we should give a category specific trophy or alarm to based on the
@@ -402,11 +408,13 @@ export default class StatTile extends Vue {
    * it should be rendered
    */
   get propertyStatRankInverted(): number | null {
-    const properStatBlock = this.BuildingStatsByPropertyType[this.propertyType];
-    if (!properStatBlock) {
+    const propertyStats = this.BuildingStatsByPropertyType[this.propertyType];
+
+    if (!propertyStats) {
       return null;
     }
-    const numBuildingsOfType: number = properStatBlock[this.statKey]?.count;
+
+    const numBuildingsOfType: number = propertyStats[this.statKey]?.count;
     const statRank = this.building[this.statKey + 'RankByPropertyType'] as string;
 
     if (statRank) {

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -229,13 +229,9 @@ export default class StatTile extends Vue {
   /** The estimated cost for the given utility */
   get costEstimate(): number | null {
     if (this.statKey === 'ElectricityUse') {
-      console.log('statValue', this.building[this.statKey]);
-
       return estimateUtilitySpend(parseFloat(this.building[this.statKey] as string), true);
     }
     else if (this.statKey === 'NaturalGasUse') {
-      console.log('statValue', this.building[this.statKey]);
-
       return estimateUtilitySpend(parseFloat(this.building[this.statKey] as string), false);
     }
 

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -32,6 +32,10 @@
         </template>
       </div>
 
+      <div v-if="costEstimate">
+        Estimated Cost: ${{ Math.round(costEstimate).toLocaleString() }}
+      </div>
+
       <!-- Only show the rank if in the top 50, #102th highest _ doesn't mean much -->
       <div
         v-if="statRank && statRank <= RankConfig.FlagRankMax && rankLabel"
@@ -178,7 +182,12 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import buildingStatsByPropertyType from "../data/dist/building-statistics-by-property-type.json";
 
 import {
-  RankConfig, getRankLabel, IBuilding, IBuildingBenchmarkStats, getRankLabelByProperty,
+  estimateUtilitySpend,
+  getRankLabel,
+  getRankLabelByProperty,
+  IBuilding,
+  IBuildingBenchmarkStats,
+  RankConfig,
 } from '~/common-functions.vue';
 
 export interface PropertyByBuildingStats
@@ -215,6 +224,22 @@ export default class StatTile extends Vue {
   get fullyGasFree(): boolean {
     return parseFloat(this.building.NaturalGasUse) === 0
       && parseFloat(this.building.DistrictSteamUse) === 0;
+  }
+
+  /** The estimated cost for the given utility */
+  get costEstimate(): number | null {
+    if (this.statKey === 'ElectricityUse') {
+      console.log('statValue', this.building[this.statKey]);
+
+      return estimateUtilitySpend(parseFloat(this.building[this.statKey] as string), true);
+    }
+    else if (this.statKey === 'NaturalGasUse') {
+      console.log('statValue', this.building[this.statKey]);
+
+      return estimateUtilitySpend(parseFloat(this.building[this.statKey] as string), false);
+    }
+
+    return null;
   }
 
   get pluralismForPropertyType(): string {

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -34,7 +34,7 @@
 
       <div v-if="costEstimate" class="bill-estimate">
         <strong>Est. {{ statKey === 'NaturalGasUse' ? 'Gas' : 'Electric' }} Bill:</strong>
-        ${{ Math.round(costEstimate).toLocaleString() }} **
+        ${{ Math.round(costEstimate).toLocaleString() }} for {{ building.DataYear }}**
       </div>
 
       <!-- Only show the rank if in the top 50, #102th highest _ doesn't mean much -->

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -297,9 +297,9 @@ query ($id: ID!) {
       <p class="constrained">
         <strong>** Note on Bill Estimates:</strong>
         Estimates for gas and electric bills are based on average electric and gas <em>retail</em>
-        prices for Chicago in {{ UtilityCosts.year }}. We expect large buildings would
-        negotiate lower rates with utilities, but these estimates serve as an upper bound of cost
-        and help understand the volume of energy a building is used by comparing it to your own
+        prices for Chicago in {{ UtilityCosts.year }} and are rounded. We expect large buildings
+        would negotiate lower rates with utilities, but these estimates serve as an upper bound of
+        cost and help understand the volume of energy a building is used by comparing it to your own
         energy bills!
 
         See our

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -303,8 +303,11 @@ query ($id: ID!) {
         energy bills!
 
         See our
-        <a :href="UtilityCosts.source" target="_blank"
-            rel="noopener">Chicago Gas & Electric Costs Source <NewTabIcon/>
+        <a
+          :href="UtilityCosts.source"
+          target="_blank"
+          rel="noopener"
+        >Chicago Gas & Electric Costs Source <NewTabIcon />
         </a>
         for the original statistics.
       </p>

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -184,10 +184,7 @@ query ($id: ID!) {
         </div>
       </div>
 
-      <h2>Emissions & Energy Information</h2>
-      <p class="year-note">
-        For {{ dataYear }}
-      </p>
+      <h2>Emissions & Energy Information for {{ dataYear }}</h2>
 
       <dl class="emission-stats">
         <div>
@@ -292,9 +289,24 @@ query ($id: ID!) {
       </dl>
 
       <p class="constrained">
-        <strong>* Important Note:</strong> Rankings and medians are among <em>included</em>
+        <strong>* Note on Rankings:</strong> Rankings and medians are among <em>included</em>
         buildings, which are those who reported under the Chicago Energy Benchmarking Ordinance for
         the year {{ LatestDataYear }}, which only applies to buildings over 50,000 square feet.
+      </p>
+
+      <p class="constrained">
+        <strong>** Note on Bill Estimates:</strong>
+        Estimates for gas and electric bills are based on average electric and gas <em>retail</em>
+        prices for Chicago in {{ UtilityCosts.year }}. We expect large buildings would
+        negotiate lower rates with utilities, but these estimates serve as an upper bound of cost
+        and help understand the volume of energy a building is used by comparing it to your own
+        energy bills!
+
+        See our
+        <a :href="UtilityCosts.source" target="_blank"
+            rel="noopener">Chicago Gas & Electric Costs Source <NewTabIcon/>
+        </a>
+        for the original statistics.
       </p>
 
       <DataSourceFootnote />
@@ -395,13 +407,11 @@ import OverallRankEmoji from '~/components/OverallRankEmoji.vue';
 import OwnerLogo from '~/components/OwnerLogo.vue';
 import StatTile from '~/components/StatTile.vue';
 
-import { IBuildingBenchmarkStats } from '~/common-functions.vue';
-
 // This simple JSON is a lot easier to just use directly than going through GraphQL and it's
 // tiny
 import BuildingBenchmarkStats from '../data/dist/building-benchmark-stats.json';
 import { getBuildingImage, IBuildingImage } from '../constants/building-images.constant.vue';
-import { IBuilding } from '../common-functions.vue';
+import { IBuilding, UtilityCosts, IBuildingBenchmarkStats } from '../common-functions.vue';
 
 @Component<any>({
   metaInfo() {
@@ -424,8 +434,11 @@ import { IBuilding } from '../common-functions.vue';
   },
 })
 export default class BuildingDetails  extends Vue {
-  /** Expose stats to readme */
+  /** Expose stats to template */
   readonly BuildingBenchmarkStats: IBuildingBenchmarkStats = BuildingBenchmarkStats;
+
+  /** Expose UtilityCosts to template */
+  readonly UtilityCosts: typeof UtilityCosts = UtilityCosts;
 
   /**
    * The year most/the latest buildings data is from - if this building's year is older than this,
@@ -560,11 +573,6 @@ export default class BuildingDetails  extends Vue {
     justify-self: flex-start;
 
     span.emoji { margin-right: 0.5rem; }
-  }
-
-  p.year-note {
-    font-size: 0.825rem;
-    margin-top: 0;
   }
 
   .address {


### PR DESCRIPTION
Adds in price estimates for the gas and electric stats, using Chicago retail average prices. Here's an example from Herman Hall:

![Screenshot from 2023-12-03 12-50-18](https://github.com/vkoves/electrify-chicago/assets/3187531/85021e7c-9024-43c5-91ef-35d2193c1b2f)

Resolves #48 