### PR TITLE
Fix Buildings With Old Stats (like United Center) Not Rendering

### DIFF
--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -252,7 +252,7 @@ export default class StatTile extends Vue {
 
   get isAboveMedian(): boolean {
     return this.building[this.statKey] !== null &&
-      this.building[this.statKey] as number > this.stats[this.statKey].median;
+    this.building[this.statKey] as number > this.stats[this.statKey].median;
   }
 
   // Square footage isn't directly climate related, so we show stats but treat it as
@@ -294,6 +294,9 @@ export default class StatTile extends Vue {
   }
 
   get medianMultiplePropertyType(): string | null {
+    if (!this.BuildingStatsByPropertyType[this.propertyType]) {
+      return null
+    }
     const median = this.BuildingStatsByPropertyType[this.propertyType][this.statKey]?.median;
     const statValueNum = parseFloat(this.building[this.statKey] as string);
 
@@ -330,6 +333,9 @@ export default class StatTile extends Vue {
 
   get propertiesToAwardThisType(): number {
     const properStatBlock = this.BuildingStatsByPropertyType[this.propertyType];
+    if (!properStatBlock) {
+      return 0
+    }
     const numBuildingsOfType = properStatBlock[this.statKey]?.count;
 
     /**
@@ -376,6 +382,9 @@ export default class StatTile extends Vue {
    */
   get propertyStatRankInverted(): number | null {
     const properStatBlock = this.BuildingStatsByPropertyType[this.propertyType];
+    if (!properStatBlock) {
+      return null
+    }
     const numBuildingsOfType: number = properStatBlock[this.statKey]?.count;
     const statRank = this.building[this.statKey + 'RankByPropertyType'] as string;
 

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -295,7 +295,7 @@ export default class StatTile extends Vue {
 
   get medianMultiplePropertyType(): string | null {
     if (!this.BuildingStatsByPropertyType[this.propertyType]) {
-      return null
+      return null;
     }
     const median = this.BuildingStatsByPropertyType[this.propertyType][this.statKey]?.median;
     const statValueNum = parseFloat(this.building[this.statKey] as string);
@@ -334,7 +334,7 @@ export default class StatTile extends Vue {
   get propertiesToAwardThisType(): number {
     const properStatBlock = this.BuildingStatsByPropertyType[this.propertyType];
     if (!properStatBlock) {
-      return 0
+      return 0;
     }
     const numBuildingsOfType = properStatBlock[this.statKey]?.count;
 
@@ -383,7 +383,7 @@ export default class StatTile extends Vue {
   get propertyStatRankInverted(): number | null {
     const properStatBlock = this.BuildingStatsByPropertyType[this.propertyType];
     if (!properStatBlock) {
-      return null
+      return null;
     }
     const numBuildingsOfType: number = properStatBlock[this.statKey]?.count;
     const statRank = this.building[this.statKey + 'RankByPropertyType'] as string;


### PR DESCRIPTION
### Description

This adds conditions to StatTile component to fix the issue where Vue was trying to render statistics like the median Greenhouse Gas Intensity but did not have the data to actually do the computation. Instead of computing those statistics, it will check whether the relevant building data is actually available for the computation.

Fixes issue #53.

### Testing Instructions

To test the case where the render was throwing issues initially, check the United Center page (building/united-airlines-reservation-center/) or the Art Institute of Chicago page (building/the-art-institute-of-chicago/), which is a different year but has data to compute medians. Any other building page should show all the median and ranking statistics underneath the various numbers for usage.

### Checklist:

- [ ] My code follows the style guidelines of this project*
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

*I don't think I saw any explicit style guidelines but maybe there's JS/TS/Vue style guidelines that apply