### PR TITLE
Fix Median Multipliers Not Showing

### DIFF
--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -113,9 +113,9 @@
         </div>
 
         <div v-if="medianMultiplePropertyType">
-          <!-- Only show median multiple if value is > 0, otherwise it's 1/infinity -->
+          <!-- Only show median multiple if the building stat is > 0, otherwise it's 1/infinity -->
           <span
-            v-if="stats[statKey] > 0"
+            v-if="statValue !== '0'"
             class="val"
           >
             {{ medianMultiplePropertyType }} median {{ propertyType }}

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -95,9 +95,9 @@
         class="median-comparison"
       >
         <div>
-          <!-- Only show median multiple if value is > 0, otherwise it's 1/infinity -->
+          <!-- Only show median multiple if the building stat is > 0, otherwise it's 1/infinity -->
           <span
-            v-if="stats[statKey] > 0"
+            v-if="statValue !== '0'"
             class="val"
           >
             {{ medianMultipleMsgCityWide }} median
@@ -222,7 +222,6 @@ export default class StatTile extends Vue {
   get propertyType(): string {
     return this.building["PrimaryPropertyType"];
   }
-
 
   /**
    * Whether a building is _fully_ gas free, meaning no natural gas burned on-site or to heat it


### PR DESCRIPTION
# Description

Fixes the city wide and property specific median multipliers not showing up (e.g. this building burned 4x the median natural gas). Here's a demo from Keating with the medians outlined:

![Screenshot from 2023-12-05 21-14-24](https://github.com/vkoves/electrify-chicago/assets/3187531/79b0fe43-d6a4-45c1-9b4c-197c0ea6c635)

Fixes #54

# Testing Instructions

Validated the median multipliers show up and are sound, and that old buildings (like United Center or the Art Institute) still work.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
