### PR TITLE
Update README.md to include docker-compose run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,51 +78,42 @@ When you see the above output, it means the site is now running and now you can 
 - To stop the server, but not destroy it (often sufficient for day-to-day work), run `docker-compose stop`
 - Bring the same server back up later with `docker-compose up`
 
-## Open Bash Shell
+## Running Commands & Tests Inside Container
 
-> [!IMPORTANT]
-> To run any of the commands below, you'll need to do the following:
-> 1. Open a new terminal and `cd` into the root project directory after spinning up your Docker container
-> 2. Open up a bash shell inside the Docker container with the following command:
-
-```bash
-docker-compose exec electrify-chicago bash
-```
 ### Run Front-End Linting
 
-To run linting with auto-fix, run the following command inside the Docker bash shell:
+To run linting with auto-fix:
 
 ```bash
-yarn lint-fix
+docker-compose run --rm electrify-chicago yarn lint-fix
 ```
 
 ### Run Data Processing
 
 1. If you update the raw data CSVs or the data scripts that post-process them (like if you are adding
 a new statistical analysis), you need to re-run the data processing. 
-
-2. To then process a new CSV file (at `src/data/source/ChicagoEnergyBenchmarking.csv`), you need to run the following command inside the Docker bash shell:
+2. To then process a new CSV file (at `src/data/source/ChicagoEnergyBenchmarking.csv`), you need to run the following command:
 
 ```bash
-bash run_all.sh
+docker-compose run --rm electrify-chicago bash run_all.sh
 ```
 
 ### Run Data Processing Tests
 
-1. Make sure test data is created/replaced before running tests by running the following script from
-the Docker bash shell (it will overwrite the existing test data file if it exists):
+1. Make sure test data is created/replaced before running tests by running the following script (it will overwrite the existing test data file if it exists):
 
 ```bash
-bash create_test_data.sh
+docker-compose run --rm electrify-chicago bash create_test_data.sh
 ```
 
-2. To run all tests in the project directory, enter the following command inside the Docker bash shell:
+2. To run all tests in the project directory, enter the following command:
 
 ```bash
-python -m pytest
+docker-compose run --rm electrify-chicago python -m pytest
 ```
-3. Run the following command for individual unit test suite (where YOUR_FILE_NAME is something like
-`test_clean_all_years`) in the Docker bash shell:
+
+3. Run the following command for individual unit test suites (where YOUR_FILE_NAME is something like
+`test_clean_all_years`):
 
 ```bash
 python -m pytest tests/data/scripts/unit/YOUR_FILE_NAME.py

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ docker-compose run --rm electrify-chicago python -m pytest
 `test_clean_all_years`):
 
 ```bash
-python -m pytest tests/data/scripts/unit/YOUR_FILE_NAME.py
+docker-compose run --rm electrify-chicago python -m pytest tests/data/scripts/unit/YOUR_FILE_NAME.py
 ```
 
 ## Managing The Data

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Docker is the recommended approach to quickly getting started with local develop
 ### **2. Start Docker**
 
 > [!IMPORTANT]
-> Please make sure the `Docker Desktop` application is **running on your computer** before you run the bash commands below.
+> Please make sure the `Docker Desktop` application is **running on your computer** before you run the commands below.
 
 This command starts server locally. To start it, `cd` into the project directory in your terminal then run the following command: 
 


### PR DESCRIPTION
# Description

Updated README to modify instructions for running tests with `docker-compose run` instead of opening bash shell

Fixes #90 

# Testing Instructions

Review the README and make sure it aligns with the changes made in issue #90 

# Checklist:

- [x] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
