### PR TITLE
98 search on map is broken

### DIFF
--- a/src/pages/Map.vue
+++ b/src/pages/Map.vue
@@ -268,22 +268,18 @@ export default class MapPage extends Vue {
 
     // Calculate the distance to each building and filter by those within a mile
     const pointsNearInputPoint = buildingNodes.filter((buildingNode: IBuildingNode) => {
-      var withinProximity = false;
-      try {
+      if (buildingNode.node.Latitude != null && buildingNode.node.Longitude != null ) {
         const buildingPoint = this.Leaflet.latLng(
           parseFloat(buildingNode.node.Latitude),
           parseFloat(buildingNode.node.Longitude),
         );
         const buildingDistanceToPointMeters = buildingPoint.distanceTo(inputPoint);
 
-        console.log(buildingDistanceToPointMeters);
-
-        withinProximity = buildingDistanceToPointMeters <= SearchRadiusMeters;
+        return buildingDistanceToPointMeters <= SearchRadiusMeters;
+      } 
+      else {
+        return false;
       }
-      catch (e) {
-        console.log(e,'\nErrored on this node:\n', buildingNode.node)
-      }
-      return withinProximity;
     });
 
     this.addBuildingsToMap(pointsNearInputPoint);

--- a/src/pages/Map.vue
+++ b/src/pages/Map.vue
@@ -268,6 +268,7 @@ export default class MapPage extends Vue {
 
     // Calculate the distance to each building and filter by those within a mile
     const pointsNearInputPoint = buildingNodes.filter((buildingNode: IBuildingNode) => {
+      // Make sure we actually have coordinates before we do calculations on them
       if (buildingNode.node.Latitude != null && buildingNode.node.Longitude != null ) {
         const buildingPoint = this.Leaflet.latLng(
           parseFloat(buildingNode.node.Latitude),

--- a/src/pages/Map.vue
+++ b/src/pages/Map.vue
@@ -269,7 +269,9 @@ export default class MapPage extends Vue {
     // Calculate the distance to each building and filter by those within a mile
     const pointsNearInputPoint = buildingNodes.filter((buildingNode: IBuildingNode) => {
       // Make sure we actually have coordinates before we do calculations on them
-      if (buildingNode.node.Latitude != null && buildingNode.node.Longitude != null ) {
+      const latFloat = parseFloat(buildingNode.node.Latitude)
+      const lonFloat = parseFloat(buildingNode.node.Longitude)
+      if (!isNaN(latFloat) && !isNaN(lonFloat)) {
         const buildingPoint = this.Leaflet.latLng(
           parseFloat(buildingNode.node.Latitude),
           parseFloat(buildingNode.node.Longitude),

--- a/src/pages/Map.vue
+++ b/src/pages/Map.vue
@@ -269,13 +269,10 @@ export default class MapPage extends Vue {
     // Calculate the distance to each building and filter by those within a mile
     const pointsNearInputPoint = buildingNodes.filter((buildingNode: IBuildingNode) => {
       // Make sure we actually have coordinates before we do calculations on them
-      const latFloat = parseFloat(buildingNode.node.Latitude)
-      const lonFloat = parseFloat(buildingNode.node.Longitude)
+      const latFloat = parseFloat(buildingNode.node.Latitude);
+      const lonFloat = parseFloat(buildingNode.node.Longitude);
       if (!isNaN(latFloat) && !isNaN(lonFloat)) {
-        const buildingPoint = this.Leaflet.latLng(
-          parseFloat(buildingNode.node.Latitude),
-          parseFloat(buildingNode.node.Longitude),
-        );
+        const buildingPoint = this.Leaflet.latLng(latFloat, lonFloat);
         const buildingDistanceToPointMeters = buildingPoint.distanceTo(inputPoint);
 
         return buildingDistanceToPointMeters <= SearchRadiusMeters;

--- a/src/pages/Map.vue
+++ b/src/pages/Map.vue
@@ -268,13 +268,22 @@ export default class MapPage extends Vue {
 
     // Calculate the distance to each building and filter by those within a mile
     const pointsNearInputPoint = buildingNodes.filter((buildingNode: IBuildingNode) => {
-      const buildingPoint = this.Leaflet.latLng(
-        parseFloat(buildingNode.node.Latitude),
-        parseFloat(buildingNode.node.Longitude),
-      );
-      const buildingDistanceToPointMeters = buildingPoint.distanceTo(inputPoint);
+      var withinProximity = false;
+      try {
+        const buildingPoint = this.Leaflet.latLng(
+          parseFloat(buildingNode.node.Latitude),
+          parseFloat(buildingNode.node.Longitude),
+        );
+        const buildingDistanceToPointMeters = buildingPoint.distanceTo(inputPoint);
 
-      return buildingDistanceToPointMeters <= SearchRadiusMeters;
+        console.log(buildingDistanceToPointMeters);
+
+        withinProximity = buildingDistanceToPointMeters <= SearchRadiusMeters;
+      }
+      catch (e) {
+        console.log(e,'\nErrored on this node:\n', buildingNode.node)
+      }
+      return withinProximity;
     });
 
     this.addBuildingsToMap(pointsNearInputPoint);


### PR DESCRIPTION
# Description

Adds a check to map search to  make sure that lat long coordinates exist before doing the proximity calculation for the map building search feature.

Fixes #98 

# Testing Instructions

Checked a couple cases in the frontend, including Willis Tower (which was shown in the original issue). Should currently show all the buildings within the correct proximity of the filtered building. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
