### PR TITLE
Remove The National office building from CPS tagging

### DIFF
--- a/src/constants/buildings-custom-info.constant.vue
+++ b/src/constants/buildings-custom-info.constant.vue
@@ -329,7 +329,7 @@ export const BuildingsCustomInfo: { [buildingId: string]: IBuildingCustomInfo } 
 
   /**
    * Northwestern Buildings
-   * Helpful source: https://maps.northwestern.edu/chicago 
+   * Helpful source: https://maps.northwestern.edu/chicago
    */
   // 303 E Superior Street
   '256405': { owner: BuildingOwners.northwestern.key },
@@ -357,7 +357,7 @@ export const BuildingsCustomInfo: { [buildingId: string]: IBuildingCustomInfo } 
   // NMH Arkes Family Pavilion, 676 N St Clair St
   '103684': {owner: BuildingOwners.northwestern.key},
   // 8792, Feinberg School of Medicine, 303 E Chicago Ave
-  '256411': {owner: BuildingOwners.northwestern.key}, 
+  '256411': {owner: BuildingOwners.northwestern.key},
 
 
   /**
@@ -1373,9 +1373,6 @@ export const BuildingsCustomInfo: { [buildingId: string]: IBuildingCustomInfo } 
   '251562': { owner: BuildingOwners.cps.key },
   // Prodigy Wood
   '251740': { owner: BuildingOwners.cps.key },
-  // CentralOffic
-  '103705': { owner: BuildingOwners.cps.key },
-
 
    /**
    * CHA


### PR DESCRIPTION
# Description

Removes [The National](https://electrifychicago.net/building/the-national/), an office building that was _formerly_ CPS' headerquarters, from the CPS tagging.

Fixes #104 

# Testing Instructions

Please describe the tests/QA that you did to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
