### PR TITLE
Creating and adding TakeActionTips page.

### DIFF
--- a/src/pages/TakeActionTips.vue
+++ b/src/pages/TakeActionTips.vue
@@ -1,0 +1,98 @@
+<template>
+    <DefaultLayout>
+      <div class="layout-constrained">
+        <section class="takeaways">
+        <h2>What Should We Do About This?</h2>
+
+        <p class="constrained">
+          Practically every building has room to improve with energy efficiency upgrades like
+          insulation, switching to ENERGY STAR rated appliances, and more, but for any buildings
+          with large natural gas use, we recommend one thing: <strong>electrify!</strong>
+        </p>
+
+        <p class="constrained">
+          In other words,
+          <strong>
+            buildings should look to move all on-site uses of fossil fuels (including
+            space heating, water heating, and cooking) to electrically powered systems
+          </strong> like
+          industrial grade heat pumps, heat pump water heaters, and induction stoves. With Illinois'
+          current electric supply, just using the same amount of energy from electricity, rather
+          than natural gas (aka methane) will dramatically reduce greenhouse gas emissions.
+          This is because Illinois' grid in 2020 was already 67% carbon-free
+          (see <a
+            href="https://decarbmystate.com/illinois#power"
+            target="_blank"
+            rel="noopener"
+          >
+            Illinois - Power | DecarbMyState <NewTabIcon />
+          </a>).
+          This has already been done across the country with a variety of buildings, large and
+          small, like the
+          <a
+            href="https://www.youtube.com/watch?v=J4aTcU6Fzoc"
+            target="_blank"
+            rel="noopener"
+          >
+            Hotel Marcel
+            <NewTabIcon />
+          </a>.
+        </p>
+
+        <p class="constrained">
+          You can help make this a reality by talking to building owners and letting them know that
+          a building's emissions are important to you, and that you want to see their building
+          become fully electric and stop emitting greenhouse gases. Particularly for buildings you
+          have a financial stake in (like your university, work, condo building, or apartment
+          building) your voice <em>in concert with your fellow building users</em> can have a huge
+          impact.
+        </p>
+
+        <h3>Additional Resources</h3>
+
+        <p>
+          See some additional resources on improving energy efficiency and understanding this data:
+
+          <ul>
+            <li>
+              <a
+                href="https://www.chicago.gov/city/en/depts/mayor/supp_info/chicago-energy-benchmarking/Chicago_Energy_Benchmarking_Beyond_Benchmarking.html"
+                target="_blank"
+                rel="noopener"
+              >
+                Chicago Energy Benchmarking: Taking Action to Improve Energy Efficiency
+                | City of Chicago <NewTabIcon />
+              </a>
+            </li>
+
+            <li>
+              <a
+                href="https://www.chicagobuilding.gov/content/dam/city/progs/env/EnergyBenchmark/2018_Chicago_Energy_Benchmarking_Results_By_Sector.pdf"
+                target="_blank"
+                rel="noopener"
+              >
+                Chicago Average EUIs and ENERGY STAR scores by property type [PDF] <NewTabIcon />
+              </a>
+            </li>
+
+            <li>
+              <a
+                href="https://portfoliomanager.energystar.gov/pdf/reference/US%20National%20Median%20Table.pdf"
+                target="_blank"
+                rel="noopener"
+              >
+                U.S. Energy Use Intensity by Property Type | ENERGY STAR [PDF] <NewTabIcon />
+              </a>
+            </li>
+          </ul>
+        </p>
+      </section>
+      </div>
+    </DefaultLayout>
+  </template>
+
+<script>
+export default {
+  name: 'TakeActionTips',
+};
+</script>

--- a/src/pages/TakeActionTips.vue
+++ b/src/pages/TakeActionTips.vue
@@ -20,7 +20,7 @@ export default class TakeActionTips extends Vue {
     <DefaultLayout>
       <div class="layout-constrained">
         <section class="takeaways">
-        <h2>What Should We Do About This?</h2>
+        <h1 id="main-content" and tabindex="-1">What Should We Do About This?</h1>
 
         <p class="constrained">
           Practically every building has room to improve with energy efficiency upgrades like

--- a/src/pages/TakeActionTips.vue
+++ b/src/pages/TakeActionTips.vue
@@ -1,3 +1,21 @@
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import NewTabIcon from '~/components/NewTabIcon.vue';
+
+// TODO: Figure out a way to get metaInfo working without any
+// https://github.com/xerebede/gridsome-starter-typescript/issues/37
+@Component<any>({
+  components: {
+    NewTabIcon,
+  },
+  metaInfo() {
+    return { title:  'Take Action' };
+  },
+})
+export default class TakeActionTips extends Vue {
+}
+</script>
+
 <template>
     <DefaultLayout>
       <div class="layout-constrained">
@@ -90,9 +108,3 @@
       </div>
     </DefaultLayout>
   </template>
-
-<script>
-export default {
-  name: 'TakeActionTips',
-};
-</script>

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -381,7 +381,7 @@ query ($id: ID!, $ID: String) {
       <DataSourceFootnote />
 
       <section class="takeaways">
-        <h2>What Should We Do About This?</h2>
+        <h1 id="main-content" tabindex="-1">What Should We Do About This?</h1>
         <a href="/take-action-tips">
           Own this Building? Take Action.
         </a>

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -382,89 +382,9 @@ query ($id: ID!, $ID: String) {
 
       <section class="takeaways">
         <h2>What Should We Do About This?</h2>
-
-        <p class="constrained">
-          Practically every building has room to improve with energy efficiency upgrades like
-          insulation, switching to ENERGY STAR rated appliances, and more, but for any buildings
-          with large natural gas use, we recommend one thing: <strong>electrify!</strong>
-        </p>
-
-        <p class="constrained">
-          In other words,
-          <strong>
-            buildings should look to move all on-site uses of fossil fuels (including
-            space heating, water heating, and cooking) to electrically powered systems
-          </strong> like
-          industrial grade heat pumps, heat pump water heaters, and induction stoves. With Illinois'
-          current electric supply, just using the same amount of energy from electricity, rather
-          than natural gas (aka methane) will dramatically reduce greenhouse gas emissions.
-          This is because Illinois' grid in 2020 was already 67% carbon-free
-          (see <a
-            href="https://decarbmystate.com/illinois#power"
-            target="_blank"
-            rel="noopener"
-          >
-            Illinois - Power | DecarbMyState <NewTabIcon />
-          </a>).
-          This has already been done across the country with a variety of buildings, large and
-          small, like the
-          <a
-            href="https://www.youtube.com/watch?v=J4aTcU6Fzoc"
-            target="_blank"
-            rel="noopener"
-          >
-            Hotel Marcel
-            <NewTabIcon />
-          </a>.
-        </p>
-
-        <p class="constrained">
-          You can help make this a reality by talking to building owners and letting them know that
-          a building's emissions are important to you, and that you want to see their building
-          become fully electric and stop emitting greenhouse gases. Particularly for buildings you
-          have a financial stake in (like your university, work, condo building, or apartment
-          building) your voice <em>in concert with your fellow building users</em> can have a huge
-          impact.
-        </p>
-
-        <h3>Additional Resources</h3>
-
-        <p>
-          See some additional resources on improving energy efficiency and understanding this data:
-
-          <ul>
-            <li>
-              <a
-                href="https://www.chicago.gov/city/en/depts/mayor/supp_info/chicago-energy-benchmarking/Chicago_Energy_Benchmarking_Beyond_Benchmarking.html"
-                target="_blank"
-                rel="noopener"
-              >
-                Chicago Energy Benchmarking: Taking Action to Improve Energy Efficiency
-                | City of Chicago <NewTabIcon />
-              </a>
-            </li>
-
-            <li>
-              <a
-                href="https://www.chicagobuilding.gov/content/dam/city/progs/env/EnergyBenchmark/2018_Chicago_Energy_Benchmarking_Results_By_Sector.pdf"
-                target="_blank"
-                rel="noopener"
-              >
-                Chicago Average EUIs and ENERGY STAR scores by property type [PDF] <NewTabIcon />
-              </a>
-            </li>
-
-            <li>
-              <a
-                href="https://portfoliomanager.energystar.gov/pdf/reference/US%20National%20Median%20Table.pdf"
-                target="_blank"
-                rel="noopener"
-              >
-                U.S. Energy Use Intensity by Property Type | ENERGY STAR [PDF] <NewTabIcon />
-              </a>
-            </li>
-          </ul>
-        </p>
+        <g-link to="/take-action-tips">
+          <button>Own this Building? Take Action.</button>
+        </g-link>
       </section>
     </div>
   </DefaultLayout>

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -382,9 +382,9 @@ query ($id: ID!, $ID: String) {
 
       <section class="takeaways">
         <h2>What Should We Do About This?</h2>
-        <g-link to="/take-action-tips">
-          <button>Own this Building? Take Action.</button>
-        </g-link>
+        <a href="/take-action-tips">
+          Own this Building? Take Action.
+        </a>
       </section>
     </div>
   </DefaultLayout>

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -381,7 +381,7 @@ query ($id: ID!, $ID: String) {
       <DataSourceFootnote />
 
       <section class="takeaways">
-        <h1 id="main-content" tabindex="-1">What Should We Do About This?</h1>
+        <h2>What Should We Do About This?</h2>
         <a href="/take-action-tips">
           Own this Building? Take Action.
         </a>


### PR DESCRIPTION
# Description

Created a page called TakeActionTips.vue, then removed the takeaways section from BuildingDetails.vue and added that into the new TakeActionTips page. Added a link under the "What Should We Do About This?" Header to navigate to the new Take Action Tips page. 

Fixes #127 

# Testing Instructions
Navigate to Building Details, scroll down to "What Should We Do About This?", then click the link that says "Own this Building? Take Action." It will then navigate you to the new page. 