### PR TITLE
Fix Years Reported Graph

### DIFF
--- a/src/components/ReportingTile.vue
+++ b/src/components/ReportingTile.vue
@@ -10,6 +10,7 @@
         {{ grade }}
       </span>
     </p>
+
     <ul>
       <li
         v-for="item in reportingHistory"
@@ -35,6 +36,12 @@
         <p>{{ item.year }}</p>
       </li>
     </ul>
+
+    <p class="footnote">
+      <strong>Note:</strong> Buildings are marked as reporting when we have greenhouse gas intensity
+      values for them, but some buildings are missing GHG intensity values but have reported the
+      underlying energy use data, but we're unsure why this is the case.
+    </p>
   </div>
 </template>
 
@@ -79,8 +86,6 @@ export default class ReportingTile extends Vue {
       { min: 0.6, grade: "D" },
       { min: 0, grade: "F" },
     ];
-
-    console.log('reportingHistory', this.reportingHistory);
 
     const score = this.reportedYearsCount / this.reportingHistory.length;
     return gradeRanges.find((range) => score >= range.min)!.grade;

--- a/src/components/ReportingTile.vue
+++ b/src/components/ReportingTile.vue
@@ -45,15 +45,15 @@ import { IHistoricData } from "../common-functions.vue";
 import { LatestDataYear } from "../constants/globals.vue";
 
 /**
- * A tile that shows the reporting history of a building. For each year, it shows a 
- * checkmark if there is data available and a cross if there is no data. It starts 
- * from the year that the building first reported their data and goes to the last year 
+ * A tile that shows the reporting history of a building. For each year, it shows a
+ * checkmark if there is data available and a cross if there is no data. It starts
+ * from the year that the building first reported their data and goes to the last year
  * of data that the website shows. It also shows a score and a letter grade depending on
  * how many years were successfully reported.
- * 
+ *
  * TODO:
  * Some examples that can be used for testing:
- * 1. United Center (reporting stops before the latest year of data -> therefore, adding the 
+ * 1. United Center (reporting stops before the latest year of data -> therefore, adding the
  *    missing years)
  * 2. Digital Printer's Row (missing reports in between years that are reported)
  * 3. Searle Chemistry Laboratory (all years reported)
@@ -80,6 +80,8 @@ export default class ReportingTile extends Vue {
       { min: 0, grade: "F" },
     ];
 
+    console.log('reportingHistory', this.reportingHistory);
+
     const score = this.reportedYearsCount / this.reportingHistory.length;
     return gradeRanges.find((range) => score >= range.min)!.grade;
   }
@@ -88,36 +90,18 @@ export default class ReportingTile extends Vue {
     return this.reportingHistory.filter((entry) => entry.isReported).length;
   }
 
+  /**
+   * Based on the historic data, create a simplified mapping of whether data was reported
+   */
   get reportingHistory(): { year: number; isReported: boolean }[] {
     if (!this.historicData || this.historicData.length === 0) return [];
 
-    const reportingHistory = [];
-    const reportedYears = this.historicData.map((entry) =>
-      parseInt(entry.DataYear),
-    );
-
-    let currentYear = reportedYears[0];
-    for (let reportedYear of reportedYears) {
-      // take care of missing years that lie in between reported years
-      while (currentYear !== reportedYear) {
-        reportingHistory.push({ year: currentYear, isReported: false });
-        currentYear++;
-      }
-      // if year is reported (standard case)
-      reportingHistory.push({ year: currentYear, isReported: true });
-      currentYear++;
-    }
-
-    /**
-     * if a building stopped reporting before the latest year that we have data for,
-     * add the missing years to history and mark them as not reported
-     */
-    while (currentYear <= LatestDataYear) {
-      reportingHistory.push({ year: currentYear, isReported: false });
-      currentYear++;
-    }
-
-    return reportingHistory;
+    return this.historicData.map((datum: IHistoricData) => {
+      return {
+        year: parseInt(datum.DataYear),
+        isReported: !isNaN(parseInt(datum.GHGIntensity)),
+      };
+    });
   }
 }
 </script>
@@ -200,7 +184,7 @@ export default class ReportingTile extends Vue {
     ul {
       column-gap: 1.5rem;
     }
-    
+
     .marker {
       width: 1.75rem;
       height: 1.75rem;

--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -112,8 +112,6 @@ export default class BarGraph extends Vue {
   }
 
   renderGraph(): void {
-    console.log(this.graphData);
-
     // Empty the SVG
     this.svg.html(null);
 


### PR DESCRIPTION
# Description

Now that we have full historic data, our reporting tile needs to account for that, rather than looking for data gaps.

| Before | After |
| --- | --- |
| ![Screenshot from 2024-11-19 20-21-05](https://github.com/user-attachments/assets/355ad030-20bb-4e05-89c7-ce3c4bba8c4a) | ![Screenshot from 2024-11-19 20-20-53](https://github.com/user-attachments/assets/2546dd49-1395-46a4-b7e5-9ba494442461) |

Fixes #136

# Testing Instructions

Spot checked against the data portal with:

- Crown Hall (didn't report in 2018 and 2022)
- Merch Mart (reported in all years, which we previously showed incorrectly)
- Water Tower (reported all years)

An interesting note - Chase Tower doesn't have GHG intensity data but _did report_, and has electricity and natural gas figures. The city has marked them as reporting, but we don't have the full data:

![Screenshot from 2024-11-19 20-25-51](https://github.com/user-attachments/assets/ba4e46b0-8a8f-4aad-83e3-52e7e30bc1c6)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
