### PR TITLE
Make Spark Line Have a Real X-Axis, Improving Clarity

### DIFF
--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -61,7 +61,7 @@ export default class BarGraph extends Vue {
   // The amount to shift the x-axis down by
   readonly xAxisOffset = 0;
 
-  readonly graphMargins = { top: 50, right: 50, bottom: 50, left: 20 };
+  readonly graphMargins = { top: 40, right: 50, bottom: 50, left: 20 };
   readonly barMargin = 0.2;
 
   randomId = Math.round(Math.random() * 1000);
@@ -226,7 +226,20 @@ export default class BarGraph extends Vue {
 
           // The min point should have its label below
           if (d.x === this.minAndMaxPoints![0].x) {
-            yPos += this.LabelFontSize * 1.5;
+            console.log(yPos, d.y);
+
+            // If the min is right at the bottom right or bottom left, render it above
+            // to prevent colliding with x-axis labels (e.g. Digital Lakeside > District Steam)
+            if (yPos > this.height * 0.9 && (xPos < 10 || xPos > this.width * 0.9)) {
+              yPos -= this.LabelFontSize * 2;
+            }
+            // If the min would intersect with the x-axis, draw it above instead
+            // (e.g. Herman Hall > Fossil Gas)
+            else if (yPos >= this.height * 0.6 && yPos <= this.height * 0.8) {
+              yPos -= this.LabelFontSize * 2;
+            }
+
+            yPos += this.LabelFontSize * 1.25;
 
             return `translate(${xPos},${yPos})`;
           }
@@ -387,10 +400,6 @@ export default class BarGraph extends Vue {
   }
 
   .x-axis {
-    .domain {
-      stroke-dasharray: 10px;
-    }
-
     .tick {
       font-size: 1.6rem;
       font-weight: normal;

--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -50,13 +50,13 @@ export default class BarGraph extends Vue {
 
   /** Underlying SVG size */
   readonly width = 320;
-  readonly height = 100;
+  readonly height = 140;
 
   /** The radius, in pixels, of the min and max dots and all the points on focus */
   readonly DotRadius = 8;
 
   /** The font-size of the label, in the <svg>'s internal space (so scaled as the SVG is scaled)' */
-  readonly LabelFontSize = 28;
+  readonly LabelFontSize = 30;
 
   // The amount to shift the x-axis down by - ideally 0, so it's accurate
   readonly xAxisOffset = 0;

--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -50,7 +50,7 @@ export default class BarGraph extends Vue {
 
   /** Underlying SVG size */
   readonly width = 320;
-  readonly height = 60;
+  readonly height = 100;
 
   /** The radius, in pixels, of the min and max dots and all the points on focus */
   readonly DotRadius = 8;
@@ -59,9 +59,9 @@ export default class BarGraph extends Vue {
   readonly LabelFontSize = 28;
 
   // The amount to shift the x-axis down by
-  readonly xAxisOffset = 60;
+  readonly xAxisOffset = 0;
 
-  readonly graphMargins = { top: 50, right: 15, bottom: 110, left: 15 };
+  readonly graphMargins = { top: 50, right: 50, bottom: 50, left: 20 };
   readonly barMargin = 0.2;
 
   randomId = Math.round(Math.random() * 1000);
@@ -140,7 +140,7 @@ export default class BarGraph extends Vue {
 
     const y = d3
       .scaleLinear()
-      .domain([d3.min(yVals) as number, d3.max(yVals) as number])
+      .domain([0, d3.max(yVals) as number])
       .rangeRound([this.height, 0]);
 
     // Render X axis
@@ -157,9 +157,12 @@ export default class BarGraph extends Vue {
           .tickSizeOuter(0), // make the x-axis a flat line, with no tick marks at the ends
       )
       .selectAll('text')
-      .attr('text-anchor', (d) => (d === maxYear ? 'end' : 'start'))
-      // shift label a bit further from the axis line
-      .attr('dy', '0.85em');
+      .attr('text-anchor', (d) => (d === maxYear ? 'start' : 'start'))
+      .attr('style', 'transform: rotate(15deg)')
+      // shift x-axis labels below the axis line
+      // .attr('dx', (d) => d === maxYear ? '-1em' : '-0.5em')
+      // shift x-axis labels below the axis line
+      .attr('dy', '1em');
 
     // Render Y axis
     this.svg
@@ -383,9 +386,15 @@ export default class BarGraph extends Vue {
     display: none;
   }
 
-  .x-axis .tick {
-    font-size: 1.6rem;
-    font-weight: normal;
+  .x-axis {
+    .domain {
+      stroke-dasharray: 10px;
+    }
+
+    .tick {
+      font-size: 1.6rem;
+      font-weight: normal;
+    }
   }
 
   // Hide y-axis via CSS, we label points instead

--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -58,7 +58,7 @@ export default class BarGraph extends Vue {
   /** The font-size of the label, in the <svg>'s internal space (so scaled as the SVG is scaled)' */
   readonly LabelFontSize = 28;
 
-  // The amount to shift the x-axis down by
+  // The amount to shift the x-axis down by - ideally 0, so it's accurate
   readonly xAxisOffset = 0;
 
   readonly graphMargins = { top: 40, right: 50, bottom: 50, left: 20 };
@@ -224,7 +224,7 @@ export default class BarGraph extends Vue {
           let xPos = x(d.x);
           let yPos = y(d.y);
 
-          // The min point should have its label below
+          // Min Point - The min point should have its label below
           if (d.x === this.minAndMaxPoints![0].x) {
             console.log(yPos, d.y);
 
@@ -233,17 +233,14 @@ export default class BarGraph extends Vue {
             if (yPos > this.height * 0.9 && (xPos < 10 || xPos > this.width * 0.9)) {
               yPos -= this.LabelFontSize * 2;
             }
-            // If the min would intersect with the x-axis, draw it above instead
-            // (e.g. Herman Hall > Fossil Gas)
-            else if (yPos >= this.height * 0.6 && yPos <= this.height * 0.8) {
-              yPos -= this.LabelFontSize * 2;
+            else {
+              // Otherwise if no special case, just draw it below
+              yPos += this.LabelFontSize * 1.25;
             }
-
-            yPos += this.LabelFontSize * 1.25;
 
             return `translate(${xPos},${yPos})`;
           }
-          // The max point has its label above
+          // Max Point -The max point has its label above
           else {
             yPos -= this.LabelFontSize * 0.5;
 
@@ -400,6 +397,12 @@ export default class BarGraph extends Vue {
   }
 
   .x-axis {
+    // Fade out the x-axis line a bit, so text rendered on top of it isn't so harsh
+    .domain {
+      opacity: 0.3;
+      stroke-width: 2px;
+    }
+
     .tick {
       font-size: 1.6rem;
       font-weight: normal;

--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -230,10 +230,12 @@ export default class BarGraph extends Vue {
 
             // If the min is right at the bottom right or bottom left, render it above
             // to prevent colliding with x-axis labels (e.g. Digital Lakeside > District Steam)
-            if (yPos > this.height * 0.9 && (xPos < 10 || xPos > this.width * 0.9)) {
+            if (
+              yPos > this.height * 0.9 &&
+              (xPos < 10 || xPos > this.width * 0.9)
+            ) {
               yPos -= this.LabelFontSize * 2;
-            }
-            else {
+            } else {
               // Otherwise if no special case, just draw it below
               yPos += this.LabelFontSize * 1.25;
             }


### PR DESCRIPTION
# Description

Our spark lines had a shifted x-axis and had graph domains of their min and max values, which meant that dramatic changes looked similar to subtle ones, and that you couldn't visually tell when a value went from 0 to a large number or vice versa. This fixes that by making sure every graph has 0 as its x-axis, and the x-axis isn't shifted. This makes large buildings with slow changes look less noticeable, but makes sure big swings are very clear. 

A clear comparison is looking at [Shop & Save Nagle](https://electrifychicago.net/building/shop-and-save-market-nagle/) (from the homepage list)

| Before | After |
| --- | --- |
| ![Screenshot from 2025-02-10 20-35-05](https://github.com/user-attachments/assets/1992bae1-f44f-4ce0-b5eb-ba04c435f63b) | ![Screenshot from 2025-02-10 20-35-07](https://github.com/user-attachments/assets/8b4bbf36-4bf4-4ee1-bfaa-bcb73f68ffd1) |

# Testing Instructions

Looked at a bunch of building details pages and confirmed the graphs didn't look broken on desktop and mobile.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
