### PR TITLE
Enable tooltips toggle on click

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -383,6 +383,7 @@ nav.pager {
  * Base Component Structure:
  *    <img
  *      v-tooltip="tooltipMessage"
+ *      :data-v-tooltip="{ tooltipConfig: { trigger: 'click hover' }}"
  *      class="tooltip"
  *      src="/help.svg"
  *      alt="Help icon"
@@ -394,6 +395,7 @@ nav.pager {
  *    Ex.
  *      <img
  *        v-tooltip.bottom="tooltipMessage"
+ *        :data-v-tooltip="{ tooltipConfig: { trigger: 'click hover' }}"
  *        class="tooltip"
  *        src="/help.svg"
  *        alt="Help icon"

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -378,6 +378,7 @@ query ($id: ID!, $ID: String) {
             />
             <img
               v-tooltip.bottom="{ content: tooltipMessage }"
+              :data-v-tooltip="{ tooltipConfig: { trigger: 'click hover'}}"
               class="tooltip"
               src="/help.svg"
               alt="Help icon"


### PR DESCRIPTION
# Description

Tooltips was not working for mobile. Enable tooltip to open on click, which allows users to open tooltips when tapped in mobile, or clicked 

Fixes #166 

# Testing Instructions

In browser, tooltips should open on hover or click. In mobile, tooltips should open on tap.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
