### PR TITLE
Optimize Dockerfile instruction order

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,20 +13,20 @@ RUN npm install -g yarn
 # Set working directory
 WORKDIR /app
 
-# Copy requirements and dependency files to the working directory
-COPY package.json .
-COPY yarn.lock .
+# Copy pyproject file to the working directory
+COPY pyproject.toml .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir .
+
+# Copy package and lock files to the working directory
+COPY package.json yarn.lock .
+
+# Install dependencies
+RUN yarn install
 
 # Copy the rest of the application code
 COPY . .
-
-# Install Python dependencies
-WORKDIR /app
-RUN pip install --no-cache-dir .
-
-WORKDIR /app
-# Install dependencies
-RUN yarn install
 
 # Expose the port that the app runs on
 EXPOSE 8080


### PR DESCRIPTION
## Description

- Move pyproject.toml/package.json/yarn.lock files to separate copies higher in the file so package manager installs are cached if unchanged.
- Remove some unneeded `WORKDIR` instructions.
- Add `.git` to the `.dockerignore` file so it isn't needlessly copied into the container.

Initial work towards #150 

I have tested the docker container builds and runs both node and python code as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
