### PR TITLE
Fix: Add rounding for big number display (Issue #187)

### DIFF
--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -121,6 +121,19 @@ export const RankConfig = {
 };
 
 /**
+ * Rounds a number to whole number if it is greater than 1000,
+ * otherwise returns the original number
+ * This function always returns a NUMBER
+ */
+ export function roundUpLargeNumber(value: number): number {
+  if (value > 1000) {
+    return Math.floor(value);
+  } else {
+    return value;
+  }
+ }
+
+/**
  * Returns a string rank for very bad buildings, or null if not in top 50
  * worst
  */

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -182,15 +182,16 @@ import LetterGrade from './LetterGrade.vue';
       if (!value) {
         return '-';
       }
-
-      return value.toLocaleString();
+      return Math.round(value).toLocaleString();
     },
 
     optionalFloat(value: number | null) {
       if (!value) {
         return '-';
       }
-
+      if(value >= 1000) {
+        return Math.floor(value).toLocaleString();
+      } 
       return value.toLocaleString();
     },
   },

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -189,6 +189,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import buildingStatsByPropertyType from '../data/dist/building-statistics-by-property-type.json';
+import { roundUpLargeNumber } from '../common-functions.vue';
 
 import {
   DataAnomalies,
@@ -397,12 +398,8 @@ export default class StatTile extends Vue {
   /** The stat value, as a string */              
   get statValueStr(): string {
     const rawValue = parseFloat(this.building[this.statKey] as string);
-    if (rawValue < 1000) {
-      return rawValue.toLocaleString();
-    } else {
-      const floorValue = Math.floor(rawValue);
-      return floorValue.toLocaleString();
-    }
+    const roundedNumber = roundUpLargeNumber(rawValue);
+    return roundedNumber.toLocaleString();
   }
 
   // Returns a rounded number or undefined if no rank
@@ -606,11 +603,7 @@ export default class StatTile extends Vue {
       datum[this.statKey as keyof IHistoricData] as string,
     );
 
-    if (statValFloat > 1_000) {
-      return Math.floor(statValFloat);
-    } else {
-      return statValFloat;
-    }
+    return roundUpLargeNumber(statValFloat);
   }
 }
 </script>

--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -393,9 +393,16 @@ export default class StatTile extends Vue {
     return this.medianMultipleMsg(median, statValueNum);
   }
 
-  /** The stat value, as a string */
+// FIXED: ADD ROUNDING FOR BIG NUMBERS
+  /** The stat value, as a string */              
   get statValueStr(): string {
-    return parseFloat(this.building[this.statKey] as string).toLocaleString();
+    const rawValue = parseFloat(this.building[this.statKey] as string);
+    if (rawValue < 1000) {
+      return rawValue.toLocaleString();
+    } else {
+      const floorValue = Math.floor(rawValue);
+      return floorValue.toLocaleString();
+    }
   }
 
   // Returns a rounded number or undefined if no rank
@@ -403,7 +410,7 @@ export default class StatTile extends Vue {
     const statRank = this.building[this.statKey + 'Rank'] as string;
 
     if (statRank) {
-      return Math.round(parseFloat(statRank));
+      return Math.round(parseFloat(statRank));      
     } else {
       return null;
     }
@@ -600,7 +607,7 @@ export default class StatTile extends Vue {
     );
 
     if (statValFloat > 1_000) {
-      return Math.round(statValFloat);
+      return Math.floor(statValFloat);
     } else {
       return statValFloat;
     }


### PR DESCRIPTION
# Description
Add a floor function with the condition that if the value is greater than 1000, round it up to a whole number; if it is less than 1000, do not make any changes.

Fixes # 
Issue #187

#Before Fix
![Screenshot 2025-06-15 at 4 00 53 AM](https://github.com/user-attachments/assets/608ebe34-e29f-431b-89d6-b23b09438ea9)
The values for District Steam Use and District Chilled Water Use are displayed with one decimal place, even if the number greater 1000.

#After Fix
![Screenshot 2025-06-15 at 3 01 14 AM](https://github.com/user-attachments/assets/a4db4e74-0cf1-458c-8d5c-cf84ce1e9c1d)

# Changes Made
1. on HistoricalBuildingDataTable.vue
![Screenshot 2025-06-15 at 3 56 21 AM](https://github.com/user-attachments/assets/1918feac-f6fa-4f43-ad59-075b2824282e)
I noticed there are comments mentioning the need to round and process an optional float to a locale string, so I added that to the code. However, this refers to the Table, so please delete my code if this is not an issue.

2. on StatTile.vue
![Screenshot 2025-06-15 at 3 08 28 AM](https://github.com/user-attachments/assets/5fedd6f0-b6f9-445c-8ff6-01b690417dfb)
This fixed the issue for the number format under District Steam Use and District Chilled Water Use


This is my first time making an open-source contribution. I'm happy to learn more if any part of this format is incorrect.