### PR TITLE
Fix Empty Columns Being Shown in Historical Data Table

### DIFF
--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -222,7 +222,9 @@ export default class HistoricalBuildingTable extends Vue {
     if (this.historicBenchmarks.length === 0) {
       return [];
     }
-    const allColKeys = Object.keys(this.historicBenchmarks[0]) as Array<keyof IHistoricData>;
+    const allColKeys = Object.keys(this.historicBenchmarks[0]) as Array<
+      keyof IHistoricData
+    >;
     const blankData = [null, '', 0.0, undefined];
 
     const notEmptyColKeys = allColKeys.filter((colKey) => {

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -32,8 +32,8 @@
 
           <!-- Energy Mix & Values -->
           <th class="text-center">Energy Mix</th>
-          <th scope="col">Electricity Use <span class="unit">kBTU</span></th>
-          <th scope="col">Fossil Gas Use <span class="unit">kBTU</span></th>
+          <th v-if="renderedColumns.includes('ElectricityUse')" scope="col">Electricity Use <span class="unit">kBTU</span></th>
+          <th v-if="renderedColumns.includes('NaturalGasUse')" scope="col">Fossil Gas Use <span class="unit">kBTU</span></th>
           <th v-if="renderedColumns.includes('DistrictSteamUse')" scope="col">
             District <br />
             Steam Use <span class="unit">kBTU</span>
@@ -130,8 +130,12 @@
               :show-labels="false"
             />
           </td>
-          <td>{{ benchmark.ElectricityUse | optionalInt }}</td>
-          <td>{{ benchmark.NaturalGasUse | optionalInt }}</td>
+          <td v-if="renderedColumns.includes('ElectricityUse')">
+            {{ benchmark.ElectricityUse | optionalInt }}
+          </td>
+          <td v-if="renderedColumns.includes('NaturalGasUse')">
+            {{ benchmark.NaturalGasUse | optionalInt }}
+          </td>
           <td v-if="renderedColumns.includes('DistrictSteamUse')">
             {{ benchmark.DistrictSteamUse | optionalInt }}
           </td>

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -223,14 +223,13 @@ export default class HistoricalBuildingTable extends Vue {
       return [];
     }
     const allColKeys: Array<string> = Object.keys(this.historicBenchmarks[0]);
-    type blankDataType = string | null | number | undefined;
-    const blankData: blankDataType[] = [null, '', 0.0, undefined];
+    const blankData: any[] = [null, '', 0.0, undefined];
     const notEmptyColKeys = allColKeys.filter((colKey: string) => {
       // A column is not empty if any of the datapoints
       // for that category are not part of our predefined
       // blank data states seen in the blankData array
-      return this.historicBenchmarks.some((year) => {
-        return !blankData.includes((year as any)[colKey]);
+      return this.historicBenchmarks.some((annualData) => {
+        return !blankData.includes((annualData as any)[colKey]);
       });
     });
     return notEmptyColKeys;

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -222,14 +222,15 @@ export default class HistoricalBuildingTable extends Vue {
     if (this.historicBenchmarks.length === 0) {
       return [];
     }
-    const allColKeys: Array<string> = Object.keys(this.historicBenchmarks[0]);
-    const blankData: any[] = [null, '', 0.0, undefined];
-    const notEmptyColKeys = allColKeys.filter((colKey: string) => {
+    const allColKeys = Object.keys(this.historicBenchmarks[0]) as Array<keyof IHistoricData>;
+    const blankData = [null, '', 0.0, undefined];
+
+    const notEmptyColKeys = allColKeys.filter((colKey) => {
       // A column is not empty if any of the datapoints
       // for that category are not part of our predefined
       // blank data states seen in the blankData array
-      return this.historicBenchmarks.some((annualData) => {
-        return !blankData.includes((annualData as any)[colKey]);
+      return this.historicBenchmarks.some((annualData: IHistoricData) => {
+        return !blankData.includes(annualData[colKey]);
       });
     });
     return notEmptyColKeys;

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -220,10 +220,10 @@ export default class HistoricalBuildingTable extends Vue {
     const notEmptyColKeys = allColKeys.filter((colKey: string) => {
       // A column is empty if it's all empty string or '0', so skip it if so. Some columns switch
       // between both, like Natural Gas Use on Merch Mart, which we also want to ignore
-      return this.historicBenchmarks.some((datum) => {
-        console.log(datum, "datum")
+      return this.historicBenchmarks.some((year) => {
+        console.log(year, "datum")
         return (
-          (datum as any)[colKey] !== "" && (datum as any)[colKey] !== 0.0 && (datum as any)[colKey] !== null
+          (year as any)[colKey] !== "" && (year as any)[colKey] !== 0.0 && (year as any)[colKey] !== null
         );
       });
     });

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -216,17 +216,19 @@ export default class HistoricalBuildingTable extends Vue {
     }
 
     const allColKeys: Array<string> = Object.keys(this.historicBenchmarks[0]);
-    const emptyColKeys = allColKeys.filter((colKey: string) => {
+    console.log(this.historicBenchmarks);
+    const notEmptyColKeys = allColKeys.filter((colKey: string) => {
       // A column is empty if it's all empty string or '0', so skip it if so. Some columns switch
       // between both, like Natural Gas Use on Merch Mart, which we also want to ignore
-      return !this.historicBenchmarks.every((datum) => {
+      return this.historicBenchmarks.some((datum) => {
+        console.log(datum, "datum")
         return (
-          (datum as any)[colKey] === '' || (datum as any)[colKey] === '0.0'
+          (datum as any)[colKey] !== "" && (datum as any)[colKey] !== 0.0 && (datum as any)[colKey] !== null
         );
       });
     });
-
-    return emptyColKeys;
+    console.log(notEmptyColKeys, "notEmptyColKeys");
+    return notEmptyColKeys;
   }
 
   calcEnergyMix(benchmarkRow: IHistoricData): {

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -233,7 +233,6 @@ export default class HistoricalBuildingTable extends Vue {
         return !blankData.includes((year as any)[colKey]);
       });
     });
-    console.log(notEmptyColKeys, 'notEmptyColKeys');
     return notEmptyColKeys;
   }
 

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -32,8 +32,12 @@
 
           <!-- Energy Mix & Values -->
           <th class="text-center">Energy Mix</th>
-          <th v-if="renderedColumns.includes('ElectricityUse')" scope="col">Electricity Use <span class="unit">kBTU</span></th>
-          <th v-if="renderedColumns.includes('NaturalGasUse')" scope="col">Fossil Gas Use <span class="unit">kBTU</span></th>
+          <th v-if="renderedColumns.includes('ElectricityUse')" scope="col">
+            Electricity Use <span class="unit">kBTU</span>
+          </th>
+          <th v-if="renderedColumns.includes('NaturalGasUse')" scope="col">
+            Fossil Gas Use <span class="unit">kBTU</span>
+          </th>
           <th v-if="renderedColumns.includes('DistrictSteamUse')" scope="col">
             District <br />
             Steam Use <span class="unit">kBTU</span>
@@ -219,19 +223,17 @@ export default class HistoricalBuildingTable extends Vue {
       return [];
     }
     const allColKeys: Array<string> = Object.keys(this.historicBenchmarks[0]);
-    console.log(this.historicBenchmarks, "historic");
-    const blankData: any[] = [null, "", 0.0, undefined];
+    type blankDataType = string | null | number | undefined;
+    const blankData: blankDataType[] = [null, '', 0.0, undefined];
     const notEmptyColKeys = allColKeys.filter((colKey: string) => {
       // A column is not empty if any of the datapoints
       // for that category are not part of our predefined
       // blank data states seen in the blankData array
       return this.historicBenchmarks.some((year) => {
-        return (
-          !blankData.includes((year as any)[colKey])
-        );
+        return !blankData.includes((year as any)[colKey]);
       });
     });
-    console.log(notEmptyColKeys, "notEmptyColKeys");
+    console.log(notEmptyColKeys, 'notEmptyColKeys');
     return notEmptyColKeys;
   }
 

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -222,7 +222,8 @@ export default class HistoricalBuildingTable extends Vue {
     console.log(this.historicBenchmarks, "historic");
     const blankData: any[] = [null, "", 0.0, undefined];
     const notEmptyColKeys = allColKeys.filter((colKey: string) => {
-      // A column is not empty if it is not part of our predefined
+      // A column is not empty if any of the datapoints
+      // for that category are not part of our predefined
       // blank data states seen in the blankData array
       return this.historicBenchmarks.some((year) => {
         return (

--- a/src/components/HistoricalBuildingDataTable.vue
+++ b/src/components/HistoricalBuildingDataTable.vue
@@ -214,16 +214,15 @@ export default class HistoricalBuildingTable extends Vue {
     if (this.historicBenchmarks.length === 0) {
       return [];
     }
-
     const allColKeys: Array<string> = Object.keys(this.historicBenchmarks[0]);
-    console.log(this.historicBenchmarks);
+    console.log(this.historicBenchmarks, "historic");
+    const blankData: any[] = [null, "", 0.0, undefined];
     const notEmptyColKeys = allColKeys.filter((colKey: string) => {
-      // A column is empty if it's all empty string or '0', so skip it if so. Some columns switch
-      // between both, like Natural Gas Use on Merch Mart, which we also want to ignore
+      // A column is not empty if it is not part of our predefined
+      // blank data states seen in the blankData array
       return this.historicBenchmarks.some((year) => {
-        console.log(year, "datum")
         return (
-          (year as any)[colKey] !== "" && (year as any)[colKey] !== 0.0 && (year as any)[colKey] !== null
+          !blankData.includes((year as any)[colKey])
         );
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "lib": ["es6", "dom", "es2016"],
+    "target": "es6",
     "module": "es6",
     "moduleResolution": "node",
     "noImplicitReturns": true,


### PR DESCRIPTION
# Description

I refactored the getrenderedColumns function in src/components/HistoricalBuildingDataTable.vue and added a null check to the filtering which I believe was an underlying issue and made some changes in variable names as seen here:
```js
getRenderedColumns(): Array<string> {
    if (this.historicBenchmarks.length === 0) {
      return [];
    }
    const allColKeys: Array<string> = Object.keys(this.historicBenchmarks[0]);
    console.log(this.historicBenchmarks, "historic");
    const blankData: any[] = [null, "", 0.0, undefined];
    const notEmptyColKeys = allColKeys.filter((colKey: string) => {
      // A column is not empty if it is not part of our predefined
      // blank data states seen in the blankData array
      return this.historicBenchmarks.some((year) => {
        return (
          !blankData.includes((year as any)[colKey])
        );
      });
    });
    console.log(notEmptyColKeys, "notEmptyColKeys");
    return notEmptyColKeys;
  }
  ```

I then noticed that the Array.includes() weren't working for some reason, so I looked into it and we were encountering this issue: https://stackoverflow.com/questions/40545329/property-includes-does-not-exist-on-type-string After I made the suggested fix in the tsconfig, the includes method was working! I then noticed that the <th> and <td> tags for the 'Electricity Use' and 'Fossil Gas Use' columns did not have v-if statements to see if they were in the getRenderedColumns array, so I added some in.

**Fixes #188**

# Testing Instructions

I looked at the numbers on the data tables manually to see that they either match the info on the live site or do not render when the entire column has blank data. I added a couple screenshots of my local version of site vs. the live site.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
<img width="868" height="509" alt="image" src="https://github.com/user-attachments/assets/f4d61849-4ef1-40c7-9f9d-2e2a80e29ffb" />
<img width="868" height="509" alt="image" src="https://github.com/user-attachments/assets/5dfd2652-3ac3-460d-be2a-f80185931048" />
