### PR TITLE
Add basic 404 page

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -41,7 +41,6 @@
     "node_modules/**/*",
     "dist/**/*",
     "build/**/*",
-    "coverage/**/*",
-    "**/*.vue"
+    "coverage/**/*"
   ]
 }

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -17,9 +17,15 @@ export default class NotFound extends Vue {}
       <h1 id="main-content" tabindex="-1">Ope, We Can't Find That Page!</h1>
 
       <p class="large-text">
-        Sorry, the page you're looking for doesn't exist. It may have been
-        moved, deleted, or you may have typed the URL incorrectly.
+        Sorry, the page you're looking for doesn't exist! <br>
       </p>
+      <p>
+        You may have followed an outdated link or have mistyped the URL.
+      </p>
+
+      <g-link to="/" class="blue-link">
+        Go Back to Our Homepage
+      </g-link>
     </div>
   </DefaultLayout>
 </template>
@@ -41,5 +47,11 @@ export default class NotFound extends Vue {}
   @media (max-width: $mobile-max-width) {
     font-size: 4rem;
   }
+}
+
+.blue-link {
+  display: inline-block;
+  margin-top: 1rem;
+  font-size: 1.125rem;
 }
 </style>

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -17,15 +17,11 @@ export default class NotFound extends Vue {}
       <h1 id="main-content" tabindex="-1">Ope, We Can't Find That Page!</h1>
 
       <p class="large-text">
-        Sorry, the page you're looking for doesn't exist! <br>
+        Sorry, the page you're looking for doesn't exist! <br />
       </p>
-      <p>
-        You may have followed an outdated link or have mistyped the URL.
-      </p>
+      <p>You may have followed an outdated link or have mistyped the URL.</p>
 
-      <g-link to="/" class="blue-link">
-        Go Back to Our Homepage
-      </g-link>
+      <g-link to="/" class="blue-link"> Go Back to Our Homepage </g-link>
     </div>
   </DefaultLayout>
 </template>

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -6,8 +6,7 @@ import { Component, Vue } from 'vue-property-decorator';
     title: 'Page Not Found',
   },
 })
-export default class NotFound extends Vue {
-}
+export default class NotFound extends Vue {}
 </script>
 
 <template>
@@ -18,8 +17,8 @@ export default class NotFound extends Vue {
       <h1 id="main-content" tabindex="-1">Ope, We Can't Find That Page!</h1>
 
       <p class="large-text">
-        Sorry, the page you're looking for doesn't exist. It may have been moved,
-        deleted, or you may have typed the URL incorrectly.
+        Sorry, the page you're looking for doesn't exist. It may have been
+        moved, deleted, or you may have typed the URL incorrectly.
       </p>
     </div>
   </DefaultLayout>
@@ -43,5 +42,4 @@ export default class NotFound extends Vue {
     font-size: 4rem;
   }
 }
-
 </style>

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component<any>({
+  metaInfo: {
+    title: 'Page Not Found',
+  },
+})
+export default class NotFound extends Vue {
+}
+</script>
+
+<template>
+  <DefaultLayout>
+    <div class="layout-constrained not-found-page">
+      <div class="error-code">404</div>
+
+      <h1 id="main-content" tabindex="-1">Ope, We Can't Find That Page!</h1>
+
+      <p class="large-text">
+        Sorry, the page you're looking for doesn't exist. It may have been moved,
+        deleted, or you may have typed the URL incorrectly.
+      </p>
+    </div>
+  </DefaultLayout>
+</template>
+
+<style lang="scss">
+.not-found-page {
+  text-align: center;
+}
+
+.error-code {
+  font-size: 6rem;
+  font-weight: bold;
+  color: $blue-dark;
+  margin: 3rem 0;
+  line-height: 1;
+  text-align: center;
+  text-shadow: 0.25rem 0.25rem 0.125rem $box-shadow-main;
+
+  @media (max-width: $mobile-max-width) {
+    font-size: 4rem;
+  }
+}
+
+</style>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -121,7 +121,7 @@ export default class Index extends Vue {
             </div>
           </form>
 
-          <g-link class="map-link" to="/map">
+          <g-link class="blue-link map-link" to="/map">
             <img src="/icons/location.svg" alt="" width="32" height="32" />
             View Map
           </g-link>
@@ -334,24 +334,10 @@ export default class Index extends Vue {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      gap: 1rem;
-      padding: 0.5rem 1rem;
-      border-radius: $brd-rad-medium;
       min-width: 10rem;
       width: 16rem;
       max-width: 60%;
-      color: $white;
-      background: $blue-dark;
-      text-decoration: none;
-      text-align: center;
       font-size: 1.25rem;
-      font-weight: bold;
-      outline-color: $chicago-blue;
-
-      &:hover,
-      &:focus {
-        background: $blue-very-dark;
-      }
     }
   }
 

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -49,6 +49,23 @@ a.grey-link {
   }
 }
 
+a.blue-link {
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: $brd-rad-medium;
+  color: $white;
+  background: $blue-dark;
+  text-decoration: none;
+  text-align: center;
+  font-weight: bold;
+  outline-color: $chicago-blue;
+
+  &:hover,
+  &:focus {
+    background: $blue-very-dark;
+  }
+}
+
 // A generic back link variant that also handles the icon within
 a.back-link {
   display: inline-flex;


### PR DESCRIPTION
# Description

Used Claude to make a simple 404 page - we can always add more to it, but this is a lot better than the current one, which looks broken:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3f8ccc0e-f5d9-4814-86f3-8ee1e10a9055" />

## Demo

| Desktop | Mobile |
| --- | --- |
| <img width="3067" height="1983" alt="image" src="https://github.com/user-attachments/assets/d91a220a-4531-4dca-8862-62a38b5ee011" />  | <img width="960" height="1891" alt="image" src="https://github.com/user-attachments/assets/6855896a-bdc5-479f-9148-7a2b420e25e5" /> |

Fixes #215 

# Testing Instructions

Go to an invalid URL (like `/test`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
