### PR TITLE
Improved All Electric & New Building Labelling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -102,10 +102,13 @@ export default tseslint.config(
           ],
         },
       ],
-
-      semi: ['error', 'always'],
       'arrow-parens': ['error', 'always'],
       'comma-dangle': ['error', 'always-multiline'],
+
+      // Prevent console.log usage (but allow console.error)
+      'no-console': ['error', { allow: ['error'] }],
+      'semi': ['error', 'always'],
+
 
       '@typescript-eslint/explicit-function-return-type': [
         'error',

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -156,6 +156,37 @@ export function fullyGasFree(building: IBuilding): boolean {
 }
 
 /**
+ * Whether a building is "new" - meaning this is the first year it has reported data
+ */
+export function isNewBuilding(
+  building: IBuilding,
+  historicData: Array<IHistoricData>,
+): boolean {
+  if (!historicData) {
+    throw new Error('Missing historicData for isNewBuilding check!');
+  }
+  // No historic data = not reported (so not new)
+  else if (historicData.length === 0) {
+    return false;
+  }
+
+  const reportedYears = historicData
+    .filter((data) => hasReportedData(data))
+    .map((data) => data.DataYear)
+    .sort((a, b) => a - b);
+
+  // Non reporting isn't new
+  if (reportedYears.length === 0) {
+    return false;
+  }
+
+  const firstReportedYear = reportedYears[0];
+  const currentDataYear = parseInt(building.DataYear.toString(), 10);
+
+  return currentDataYear === firstReportedYear;
+}
+
+/**
  * Types for Citywide Stats
  */
 export interface DataPoint {

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -125,8 +125,6 @@ export function isZeroOrNull(value: number | null): boolean {
  * We do not mark this as true if we have detected gas use in the past
  */
 export function fullyGasFree(building: IBuilding): boolean {
-  console.log('building ' + building.PropertyName, building);
-
   if (typeof building.DataAnomalies !== 'string') {
     throw new Error('Missing building.DataAnomalies for fullyGasFree check!');
   }

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -114,6 +114,30 @@ export function hasReportedData(historicData: IHistoricData): boolean {
   );
 }
 
+export function isZeroOrNull(value: number | null): boolean {
+  return value === 0 || value === null;
+}
+
+/**
+ * Whether a building is _fully_ gas free, meaning no gas burned on-site or to heat it
+ * through a district heating system. That means it's all electric!
+ *
+ * We do not mark this as true if we have detected gas use in the past
+ */
+export function fullyGasFree(building: IBuilding): boolean {
+  console.log('building ' + building.PropertyName, building);
+
+  if (typeof building.DataAnomalies !== 'string') {
+    throw new Error('Missing building.DataAnomalies for fullyGasFree check!');
+  }
+
+  return (
+    !building.DataAnomalies.includes(DataAnomalies.gasZeroWithPreviousUse) &&
+    isZeroOrNull(building.NaturalGasUse) &&
+    isZeroOrNull(building.DistrictSteamUse)
+  );
+}
+
 /**
  * Types for Citywide Stats
  */

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { IPieSlice } from './components/graphs/PieChart.vue';
+import { LatestDataYear } from './constants/globals.vue';
 
 export default {};
 
@@ -186,7 +187,7 @@ export function isNewBuilding(
   // 1. It's currently reporting in the latest data year (2023)
   // 2. AND this is the first year it has ever reported
   // 3. AND it only has one year of reported data
-  const isReportingInLatestYear = currentDataYear === 2023; // TODO: use LatestDataYear constant
+  const isReportingInLatestYear = currentDataYear === LatestDataYear;
   const hasOnlyOneYearOfData = reportedYears.length === 1;
   const firstReportedYear = reportedYears[0];
   const isFirstYearEqualToLatest = firstReportedYear === currentDataYear;

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -180,10 +180,20 @@ export function isNewBuilding(
     return false;
   }
 
-  const firstReportedYear = reportedYears[0];
   const currentDataYear = parseInt(building.DataYear.toString(), 10);
 
-  return currentDataYear === firstReportedYear;
+  // A building is "new" if:
+  // 1. It's currently reporting in the latest data year (2023)
+  // 2. AND this is the first year it has ever reported
+  // 3. AND it only has one year of reported data
+  const isReportingInLatestYear = currentDataYear === 2023; // TODO: use LatestDataYear constant
+  const hasOnlyOneYearOfData = reportedYears.length === 1;
+  const firstReportedYear = reportedYears[0];
+  const isFirstYearEqualToLatest = firstReportedYear === currentDataYear;
+
+  return (
+    isReportingInLatestYear && hasOnlyOneYearOfData && isFirstYearEqualToLatest
+  );
 }
 
 /**

--- a/src/common-functions.vue
+++ b/src/common-functions.vue
@@ -119,15 +119,34 @@ export function isZeroOrNull(value: number | null): boolean {
 }
 
 /**
+ * Type guard to ensure required building properties exist for calculations
+ */
+export function validateBuildingProperties<T extends IBuilding>(
+  building: T,
+  properties: (keyof T)[],
+  functionName: string,
+): void {
+  for (const prop of properties) {
+    if (typeof building[prop] === 'undefined') {
+      throw new Error(
+        `Missing building.${String(prop)} for ${functionName} check!`,
+      );
+    }
+  }
+}
+
+/**
  * Whether a building is _fully_ gas free, meaning no gas burned on-site or to heat it
  * through a district heating system. That means it's all electric!
  *
  * We do not mark this as true if we have detected gas use in the past
  */
 export function fullyGasFree(building: IBuilding): boolean {
-  if (typeof building.DataAnomalies !== 'string') {
-    throw new Error('Missing building.DataAnomalies for fullyGasFree check!');
-  }
+  validateBuildingProperties(
+    building,
+    ['DataAnomalies', 'NaturalGasUse', 'DistrictSteamUse'],
+    'fullyGasFree',
+  );
 
   return (
     !building.DataAnomalies.includes(DataAnomalies.gasZeroWithPreviousUse) &&

--- a/src/components/BuildingTile.vue
+++ b/src/components/BuildingTile.vue
@@ -43,9 +43,10 @@ export default class BuildingTile extends Vue {
     <g-link :to="path" class="tile-link" tabindex="-1">
       <div class="building-tile">
         <div class="img-cont">
-          <div class="pills-cont">
+          <div class="pills-cont -small">
             <div v-if="fullyGasFree" class="pill -all-electric">
-              <span>⚡</span> All Electric
+              <span class="icon">⚡</span>
+              <span class="text">All Electric</span>
             </div>
           </div>
 
@@ -55,7 +56,7 @@ export default class BuildingTile extends Vue {
           <img v-if="buildingImg" :src="buildingImg.imgUrl" alt="" />
         </div>
 
-        <div class="text">
+        <div class="main-text">
           <g-link :to="path">
             <div class="title">
               {{ building.PropertyName }}
@@ -165,22 +166,6 @@ export default class BuildingTile extends Vue {
       position: absolute;
       top: 0.5rem;
       right: 0.5rem;
-
-      .pill {
-        font-weight: bold;
-        padding: 0.125rem 1rem;
-        border-radius: 1rem;
-        font-size: 0.875rem;
-
-        &.-all-electric {
-          background: #fff6aa;
-          color: #9e5e00;
-        }
-
-        span {
-          text-shadow: 0.0625rem 0 0.0625rem $black;
-        }
-      }
     }
 
     img {
@@ -192,7 +177,7 @@ export default class BuildingTile extends Vue {
     }
   }
 
-  .text {
+  .main-text {
     padding: 0.75rem 1rem;
 
     a {

--- a/src/components/BuildingTile.vue
+++ b/src/components/BuildingTile.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
-import { IBuilding } from '../common-functions.vue';
+import { fullyGasFree, IBuilding } from '../common-functions.vue';
 import {
   getBuildingImage,
   IBuildingImage,
@@ -31,14 +31,9 @@ export default class BuildingTile extends Vue {
     return getBuildingImage(this.building);
   }
 
-  /**
-   * Whether a building is _fully_ gas free, meaning no gas burned on-site or to heat it
-   * through a district heating system.
-   */
+  /** Whether we know this building is all electric */
   get fullyGasFree(): boolean {
-    return (
-      this.building.NaturalGasUse === 0 && this.building.DistrictSteamUse === 0
-    );
+    return fullyGasFree(this.building);
   }
 }
 </script>

--- a/src/components/BuildingsTable.vue
+++ b/src/components/BuildingsTable.vue
@@ -120,6 +120,9 @@ export default class BuildingsTable extends Vue {
       'AvgPercentileLetterGrade',
       'DataYear',
       'DataAnomalies',
+      // For gas free check
+      'NaturalGasUse',
+      'DistrictSteamUse',
     ];
 
     const conditionalFields = [

--- a/src/components/OverallRankEmoji.vue
+++ b/src/components/OverallRankEmoji.vue
@@ -63,6 +63,7 @@ import { LatestDataYear } from '../constants/globals.vue';
  * Requires columns
  *
  * - DataAnomalies
+ * - NaturalGasUse
  */
 @Component
 export default class OverallRankEmoji extends Vue {
@@ -102,8 +103,6 @@ export default class OverallRankEmoji extends Vue {
   }
 
   get isGasFree(): boolean {
-    console.log('building ' + this.building.PropertyName, this.building);
-
     return fullyGasFree(this.building);
   }
 }
@@ -114,8 +113,9 @@ export default class OverallRankEmoji extends Vue {
   display: inline;
 
   .emoji {
-    vertical-align: 0.2em;
+    vertical-align: 0.1em;
     cursor: help;
+    text-shadow: 0.0625rem 0.0625rem 0 rgba(0, 0, 0, 0.25);
   }
 
   .overall-rank-emoji {

--- a/src/components/OverallRankEmoji.vue
+++ b/src/components/OverallRankEmoji.vue
@@ -19,6 +19,14 @@
     </span>
 
     <span
+      v-if="isGasFree && !largeView"
+      class="emoji has-img-emoji"
+      title="All Electric!"
+    >
+      ⚡
+    </span>
+
+    <span
       v-if="isOldData && !largeView"
       class="emoji has-img-emoji"
       title="Outdated data (did not submit in the latest year)"
@@ -40,6 +48,7 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 
 import {
+  fullyGasFree,
   getOverallRankEmoji,
   IBuilding,
   IBuildingBenchmarkStats,
@@ -49,7 +58,7 @@ import { LatestDataYear } from '../constants/globals.vue';
 
 /**
  * A component that shows an emoji to summarize a building, showing the worse of the alarm or flag
- * emoji if those apply, or the trophy emoji if there's no flags and the building gets a trophy
+ * emoji if those apply, or the trophy emoji if there's no flags and the building gets a trophy.
  *
  * Requires columns
  *
@@ -90,6 +99,12 @@ export default class OverallRankEmoji extends Vue {
     }
 
     return this.building.DataAnomalies.length > 0;
+  }
+
+  get isGasFree(): boolean {
+    console.log('building ' + this.building.PropertyName, this.building);
+
+    return fullyGasFree(this.building);
   }
 }
 </script>

--- a/src/components/ReportCard.vue
+++ b/src/components/ReportCard.vue
@@ -51,7 +51,7 @@ export default class ReportCard extends Vue {
       :class="{ '-faded': !showingWarning }"
     >
       <div class="warning-inner">
-        <h2>Warning - Data Discrepencies Detected</h2>
+        <h2>Warning - Data Discrepancies Detected</h2>
 
         <p>
           We detected some issues with this building's data, so these grades may

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -65,7 +65,7 @@ export default class AppHeader extends Vue {
         :aria-expanded="mobileMenuOpen.toString()"
         @click="toggleMobileMenu"
       >
-        <img src="/menu.svg" alt="Menu" width="30" height="30" />
+        <img src="/menu.svg" alt="Menu" width="25" height="25" />
       </button>
     </div>
 
@@ -171,6 +171,9 @@ header.header {
     display: none;
   }
 
+  /**
+   * Mobile Styling
+   */
   @media (max-width: $mobile-max-width) {
     position: relative;
     flex-wrap: wrap;
@@ -185,7 +188,7 @@ header.header {
 
     .header-primary,
     .top-nav {
-      padding: 1rem;
+      padding: 0.5rem 0.75rem;
     }
 
     .header-primary {
@@ -211,7 +214,7 @@ header.header {
 
     .logo-link {
       flex-shrink: initial;
-      width: 70%;
+      width: 60%;
       max-width: 22rem;
 
       .site-logo {

--- a/src/pages/BiggestBuildings.vue
+++ b/src/pages/BiggestBuildings.vue
@@ -53,6 +53,7 @@ export default class BiggestBuildings extends Vue {
           NaturalGasUse
           NaturalGasUseRank
           NaturalGasUsePercentileRank
+          DistrictSteamUse
           AvgPercentileLetterGrade
           DataAnomalies
         }

--- a/src/pages/CleanestBuildings.vue
+++ b/src/pages/CleanestBuildings.vue
@@ -65,6 +65,7 @@ export default class CleanestBuildings extends Vue {
           NaturalGasUse
           NaturalGasUseRank
           NaturalGasUsePercentileRank
+          DistrictSteamUse
           AvgPercentileLetterGrade
           EnergyMixLetterGrade
           DataAnomalies

--- a/src/pages/HighestEmissionsIntensity.vue
+++ b/src/pages/HighestEmissionsIntensity.vue
@@ -82,6 +82,7 @@ export default class HighestEmissionsIntensity extends Vue {
           NaturalGasUse
           NaturalGasUseRank
           NaturalGasUsePercentileRank
+          DistrictSteamUse
           DataAnomalies
         }
       }

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -89,6 +89,7 @@ export default class Index extends Vue {
           NaturalGasUse
           DistrictSteamUse
           AvgPercentileLetterGrade
+          DataAnomalies
         }
       }
     }

--- a/src/pages/LatestUpdates.vue
+++ b/src/pages/LatestUpdates.vue
@@ -35,9 +35,7 @@ export default class LatestUpdates extends Vue {
     allPreviousYearsBenchmarks: { edges: Array<{ node: IHistoricData }> };
   };
 
-  mounted(): void {
-    console.log(this.$static.allBuilding);
-  }
+  mounted(): void {}
 
   // Import the smooth scroll function from common-functions
   readonly smoothlyScrollToAnchor = smoothlyScrollToAnchor;

--- a/src/pages/LatestUpdates.vue
+++ b/src/pages/LatestUpdates.vue
@@ -291,7 +291,7 @@ export default class LatestUpdates extends Vue {
     <!-- New Buildings Section -->
     <section>
       <h2 id="new-buildings" tabindex="-1">
-        New Buildings ({{ newBuildings.length }})
+        New Buildings In {{ LatestDataYear }} ({{ newBuildings.length }})
       </h2>
       <p>
         These buildings first submitted data in {{ LatestDataYear }} - they may
@@ -315,11 +315,14 @@ export default class LatestUpdates extends Vue {
     <!-- Stopped Reporting Section -->
     <section>
       <h2 id="stopped-reporting" tabindex="-1">
-        Stopped Reporting ({{ stoppedReportingBuildings.length }})
+        Stopped Reporting In {{ LatestDataYear }} ({{
+          stoppedReportingBuildings.length
+        }})
       </h2>
       <p>
-        Submitted data in {{ PreviousDataYear }} but not {{ LatestDataYear }},
-        sorted by square footage (largest first)
+        These buildings submitted data in {{ PreviousDataYear }} but not
+        {{ LatestDataYear }}, meaning they either fell into non-compliance or
+        were demolished. Sorted by square footage (largest first).
       </p>
 
       <p v-if="stoppedReportingBuildings.length === 0" class="no-results">

--- a/src/pages/LatestUpdates.vue
+++ b/src/pages/LatestUpdates.vue
@@ -146,6 +146,8 @@ export default class LatestUpdates extends Vue {
           TotalGHGEmissions
           TotalGHGEmissionsRank
           TotalGHGEmissionsPercentileRank
+          NaturalGasUse
+          DistrictSteamUse
           AvgPercentileLetterGrade
           DataAnomalies
         }

--- a/src/pages/RetrofitChicagoParticipants.vue
+++ b/src/pages/RetrofitChicagoParticipants.vue
@@ -62,6 +62,7 @@ export default class ChicagoRetrofitParticipants extends Vue {
     const missing = expectedIds.filter((id) => !actualIds.includes(id));
     const extra = actualIds.filter((id) => !expectedIds.includes(id));
 
+    // If anything is off, throw an error
     if (missing.length > 0 || extra.length > 0) {
       const details = [
         missing.length > 0 && `Missing: [${missing.join(', ')}]`,
@@ -75,8 +76,6 @@ export default class ChicagoRetrofitParticipants extends Vue {
           'Update GraphQL query to match hasRetrofitCaseStudy tags.',
       );
     }
-
-    console.log(`✅ Retrofit validation: ${actualIds.length} buildings`);
   }
 }
 </script>
@@ -114,6 +113,8 @@ export default class ChicagoRetrofitParticipants extends Vue {
           TotalGHGEmissionsRank
           TotalGHGEmissionsPercentileRank
           AvgPercentileLetterGrade
+          NaturalGasUse
+          DistrictSteamUse
           DataAnomalies
         }
       }

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -299,6 +299,8 @@ export default class Search extends Vue {
           TotalGHGEmissionsRank
           TotalGHGEmissionsPercentileRank
           AvgPercentileLetterGrade
+          NaturalGasUse
+          DistrictSteamUse
           DataAnomalies
         }
       }

--- a/src/pages/TopElectricityUsers.vue
+++ b/src/pages/TopElectricityUsers.vue
@@ -47,6 +47,7 @@ export default class TopElectricityUsers extends Vue {}
           NaturalGasUse
           NaturalGasUseRank
           NaturalGasUsePercentileRank
+          DistrictSteamUse
           AvgPercentileLetterGrade
           DataAnomalies
         }

--- a/src/pages/TopEmitters.vue
+++ b/src/pages/TopEmitters.vue
@@ -48,6 +48,7 @@ export default class TopEmitters extends Vue {}
           NaturalGasUseRank
           NaturalGasUsePercentileRank
           AvgPercentileLetterGrade
+          DistrictSteamUse
           DataAnomalies
         }
       }

--- a/src/pages/TopGasUsers.vue
+++ b/src/pages/TopGasUsers.vue
@@ -46,6 +46,7 @@ export default class TopGasUsers extends Vue {}
           ElectricityUsePercentileRank
           NaturalGasUse
           NaturalGasUseRank
+          DistrictSteamUse
           NaturalGasUsePercentileRank
           AvgPercentileLetterGrade
           DataAnomalies

--- a/src/pages/blog/GHGIntensityPredictCompliance.vue
+++ b/src/pages/blog/GHGIntensityPredictCompliance.vue
@@ -31,15 +31,12 @@ export default class MillionsInMissedFine extends Vue {
     const jsonFilePath =
       '/blog/GHGIntensityPredictCompliance/regression_results_w_covid.json';
 
-    console.log('Fetching JSON from:', jsonFilePath);
-
     try {
       const response = await fetch(jsonFilePath);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       this.results = await response.json();
-      console.log('Loaded regression results:', this.results);
     } catch (error) {
       console.error('Error loading regression results:', error);
     } finally {

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -26,6 +26,9 @@ $warning-background: #fcfcde;
 $warning-border: #ee8a4c;
 $box-shadow-main: rgba(0, 0, 0, 0.25);
 
+$electric-brown: #9e5e00;
+$electric-yellow: #fff6aa;
+
 // Letter grade colors
 $grade-a-green: #009f49;
 $grade-b-green: #7fa52e;

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -427,6 +427,45 @@ form.search-form {
   }
 }
 
+/** A container for little building pills, like All Electric */
+.pills-cont {
+  display: inline-block;
+
+  &.-small {
+    font-size: 0.875rem;
+  }
+
+  // When pills are links, add a border and highlight the text on hover or focus
+  a.pill {
+    text-decoration: none;
+    border: solid $border-thin $electric-brown;
+
+    &:hover,
+    &:focus {
+      .text {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .pill {
+    display: inline-block;
+    font-weight: bold;
+    padding: 0.125rem 1rem;
+    border-radius: 1rem;
+
+    &.-all-electric {
+      background: $electric-yellow;
+      color: $electric-brown;
+    }
+
+    span.icon {
+      text-shadow: 0.0625rem 0 0.0625rem $black;
+      margin-right: 0.25em;
+    }
+  }
+}
+
 /**
  * Data update banner - global notice panel for announcing new data releases
  */

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -429,7 +429,8 @@ form.search-form {
 
 /** A container for little building pills, like All Electric */
 .pills-cont {
-  display: inline-block;
+  display: inline-flex;
+  gap: 0.5rem;
 
   &.-small {
     font-size: 0.875rem;
@@ -438,12 +439,36 @@ form.search-form {
   // When pills are links, add a border and highlight the text on hover or focus
   a.pill {
     text-decoration: none;
-    border: solid $border-thin $electric-brown;
+    border: solid $border-medium $grey;
+    transition:
+      color 0.3s,
+      background-color 0.3s,
+      border-color 0.3s;
+
+    &.-new {
+      border-color: $blue-very-dark;
+
+      &:hover,
+      &:focus {
+        background-color: $blue-very-dark;
+        color: $white;
+      }
+    }
+
+    &.-all-electric {
+      border-color: $electric-brown;
+
+      &:hover,
+      &:focus {
+        background-color: $electric-brown;
+        color: $white;
+      }
+    }
 
     &:hover,
     &:focus {
       .text {
-        text-decoration: underline;
+        text-decoration: none;
       }
     }
   }
@@ -459,9 +484,14 @@ form.search-form {
       color: $electric-brown;
     }
 
+    &.-new {
+      background: $blue-light;
+      color: $blue-very-dark;
+    }
+
     span.icon {
       text-shadow: 0.0625rem 0 0.0625rem $black;
-      margin-right: 0.25em;
+      margin-right: 0.5em;
     }
   }
 }

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -131,6 +131,17 @@ query ($id: ID!, $ID: String) {
           <p class="building-id -no-margin no-print">
             Chicago Building ID: {{ $page.building.ID }}
           </p>
+
+          <div class="pills-cont">
+            <g-link
+              v-if="fullyGasFree"
+              class="pill -all-electric"
+              to="/biggest-gas-free-buildings"
+            >
+              <span class="icon">⚡</span>
+              <span class="text">All Electric</span>
+            </g-link>
+          </div>
         </div>
 
         <div class="building-img-cont">
@@ -632,6 +643,7 @@ import {
 import {
   calculateEnergyBreakdown,
   DataAnomalies,
+  fullyGasFree,
   IBuilding,
   IBuildingBenchmarkStats,
   IHistoricData,
@@ -768,6 +780,10 @@ export default class BuildingDetails extends Vue {
   /** A helper to get the current building, but with proper typing */
   get building(): IBuilding {
     return this.$page.building;
+  }
+
+  get fullyGasFree(): boolean {
+    return fullyGasFree(this.building);
   }
 
   /** Helper for property name with address fallback */
@@ -1094,6 +1110,10 @@ export default class BuildingDetails extends Vue {
   .building-id {
     font-size: 0.75rem;
     margin-top: 0;
+  }
+
+  .pills-cont {
+    margin-top: 0.5rem;
   }
 
   .building-top-info {

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -1282,7 +1282,6 @@ export default class BuildingDetails extends Vue {
 
       .building-header-text {
         position: relative;
-        margin-bottom: 0;
 
         .address {
           font-size: 1rem;
@@ -1321,6 +1320,11 @@ export default class BuildingDetails extends Vue {
         // Constrain tall images on mobile so they don't take up the whole view height
         .building-img-cont.-tall {
           width: 75%;
+
+          img {
+            max-height: 25rem;
+            width: min-content;
+          }
         }
       }
 

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -141,6 +141,14 @@ query ($id: ID!, $ID: String) {
               <span class="icon">⚡</span>
               <span class="text">All Electric</span>
             </g-link>
+
+            <g-link
+              v-if="isNew"
+              class="pill -new"
+              to="/latest-updates#new-buildings"
+            >
+              <span class="text">New!</span>
+            </g-link>
           </div>
         </div>
 
@@ -647,6 +655,7 @@ import {
   IBuilding,
   IBuildingBenchmarkStats,
   IHistoricData,
+  isNewBuilding,
   parseAnomalies,
   UtilityCosts,
 } from '../common-functions.vue';
@@ -784,6 +793,10 @@ export default class BuildingDetails extends Vue {
 
   get fullyGasFree(): boolean {
     return fullyGasFree(this.building);
+  }
+
+  get isNew(): boolean {
+    return isNewBuilding(this.building, this.historicData);
   }
 
   /** Helper for property name with address fallback */

--- a/src/templates/BuildingOwner.vue
+++ b/src/templates/BuildingOwner.vue
@@ -140,6 +140,8 @@ export default class BiggestBuildings extends Vue {
           TotalGHGEmissionsRank
           TotalGHGEmissionsPercentileRank
           AvgPercentileLetterGrade
+          NaturalGasUse
+          DistrictSteamUse
           DataAnomalies
         }
       }

--- a/src/templates/Ward.vue
+++ b/src/templates/Ward.vue
@@ -129,34 +129,11 @@ query ($ward: String) {
             GHGIntensityPercentileRank
             TotalGHGEmissionsRank
             TotalGHGEmissionsPercentileRank
-            ElectricityUseRank
-            ElectricityUsePercentileRank
-            NaturalGasUseRank
-            NaturalGasUsePercentileRank
+            NaturalGasUse
+            DistrictSteamUse
             GrossFloorAreaRank
             GrossFloorAreaPercentileRank
-            SourceEUIRank
-            SourceEUIPercentileRank
-            SiteEUIRank
-            SiteEUIPercentileRank
-            GHGIntensityRankByPropertyType
-            TotalGHGEmissionsRankByPropertyType
-            ElectricityUseRankByPropertyType
-            NaturalGasUseRankByPropertyType
-            GrossFloorAreaRankByPropertyType
-            SourceEUIRankByPropertyType
-            SiteEUIRankByPropertyType
             DataAnomalies
-            Ward
-            # Grade data
-            GHGIntensityPercentileGrade,
-            GHGIntensityLetterGrade,
-            EnergyMixWeightedPctSum,
-            EnergyMixPercentileGrade,
-            EnergyMixLetterGrade,
-            MissingRecordsCount,
-            SubmittedRecordsPercentileGrade,
-            SubmittedRecordsLetterGrade,
             AvgPercentileGrade,
             AvgPercentileLetterGrade,
         }


### PR DESCRIPTION
# Description

This PR fixes the all electric label being broken on the homepage (due to getting blank values rather than 0 for `NaturalGasUse`) and adds that label to the building tables and the top of the details page, along with a "New" pill on building details for buildings that are reporting for the first year. Each of these pills links out to the related pages, helping improve discoverability for our all electric page and our latest updates page!

| Table with All-Electric Lighting | Details Page With Both Pills |
| --- | --- |
| <img width="3623" height="2984" alt="image" src="https://github.com/user-attachments/assets/0e7d1a2e-c2b0-4cc0-b7fc-4359e00c8373" /> | <img width="3623" height="2984" alt="Screenshot from 2025-08-25 22-22-56" src="https://github.com/user-attachments/assets/96682b69-a2a2-40e6-b100-3856ae042055" /> |

**This also fixes all electric buildings marked as gas "not reporting"**. On prod right now, Marina towers just says that it didn't report gas use - but we _know_ (with high confidence) that it's electric since it has never reported gas use.

Fixes #219, fixes #221, fixes #222

# Testing Instructions

Manual QA - I confirmed all the lists of buildings load and show all electric buildings, including the ward pages, building owners, all the pages in the about page, and all the pages in the header. We should really add some more robust automated testing for that though 😅 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
