### PR TITLE
Rename Gas Free Buildings to All Electric Buildings

### DIFF
--- a/src/components/StatTile.vue
+++ b/src/components/StatTile.vue
@@ -144,8 +144,8 @@
           <p class="smaller">
             This building burned no fossil gas on-site and isn't connected to a
             district heating system, meaning it's fully electric! View
-            <g-link to="/biggest-gas-free-buildings">
-              All of Chicago's Biggest Gas Free Buildings</g-link
+            <g-link to="/all-electric">
+              All of Chicago's All Electric Buildings</g-link
             >.
           </p>
         </div>

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -149,9 +149,7 @@ export default class About extends Vue {
           <g-link to="/top-electricity-users"> Top Electricity Users </g-link>
         </li>
         <li>
-          <g-link to="/biggest-gas-free-buildings">
-            Biggest Gas Free Buildings
-          </g-link>
+          <g-link to="/all-electric"> All Electric Buildings </g-link>
         </li>
         <li>
           <g-link to="/retrofit-chicago-participants">

--- a/src/pages/AllElectric.vue
+++ b/src/pages/AllElectric.vue
@@ -1,0 +1,108 @@
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+import BuildingsTable from '~/components/BuildingsTable.vue';
+import DataDisclaimer from '~/components/DataDisclaimer.vue';
+import DataSourceFootnote from '~/components/DataSourceFootnote.vue';
+import NewTabIcon from '~/components/NewTabIcon.vue';
+
+/**
+ * All Electric Buildings page - shows the largest all-electric buildings in Chicago
+ *
+ * NOTE: This page was previously located at /biggest-gas-free-buildings before Aug. 27th, 2025.
+ * The old route redirects to this new location for backwards compatibility.
+ */
+// TODO: Figure out a way to get metaInfo working without any
+// https://github.com/xerebede/gridsome-starter-typescript/issues/37
+@Component<any>({
+  components: {
+    BuildingsTable,
+    DataDisclaimer,
+    DataSourceFootnote,
+    NewTabIcon,
+  },
+  metaInfo() {
+    return { title: 'All Electric Buildings' };
+  },
+})
+export default class AllElectric extends Vue {}
+</script>
+
+<static-query>
+  query {
+    allBuilding(
+      filter: {
+        DataYear: { eq: "2023" },
+        # Use lte: 0 to capture buildings with 0, null, or empty values for gas usage
+        NaturalGasUse: { lte: 0 },
+        DistrictSteamUse: { lte: 0 },
+        # Exclude buildings that previously used gas but now report zero
+        DataAnomalies: { nin: ["gasZeroWithPreviousUse"] }
+      },
+      sortBy: "GrossFloorArea", limit: 500
+    ) {
+      edges {
+        node {
+          slugSource
+          ID
+          DataYear
+          PropertyName
+          Address
+          ZIPCode
+          path
+          GrossFloorArea
+          GrossFloorAreaRank
+          GrossFloorAreaPercentileRank
+          PrimaryPropertyType
+          GHGIntensity
+          GHGIntensityRank
+          GHGIntensityPercentileRank
+          TotalGHGEmissions
+          TotalGHGEmissionsRank
+          TotalGHGEmissionsPercentileRank
+          ElectricityUse
+          ElectricityUseRank
+          ElectricityUsePercentileRank
+          NaturalGasUse
+          NaturalGasUseRank
+          NaturalGasUsePercentileRank
+          DistrictSteamUse
+          AvgPercentileLetterGrade
+          DataAnomalies
+        }
+      }
+    }
+  }
+</static-query>
+
+<template>
+  <DefaultLayout>
+    <h1 id="main-content" tabindex="-1">
+      Chicago's {{ $static.allBuilding.edges.length }} All Electric Buildings
+    </h1>
+
+    <p class="constrained -wide">
+      These buildings are already all-electric, and feature some of the most
+      famous buildings in the city! If even the John Hancock center or Marina
+      Towers can run off of only electricity, your building can too.
+    </p>
+
+    <p class="constrained -wide">
+      <strong>Note:</strong> This list is of buildings that use neither fossil
+      gas nor a district steam system, since all district steam systems in the
+      city are currently powered by burning fossil gas (to the best of our
+      knowledge).
+    </p>
+
+    <DataDisclaimer />
+
+    <BuildingsTable
+      :buildings="$static.allBuilding.edges"
+      :show-square-footage="true"
+    />
+
+    <DataSourceFootnote />
+  </DefaultLayout>
+</template>
+
+<style lang="scss"></style>

--- a/src/pages/BiggestGasFreeBuildings.vue
+++ b/src/pages/BiggestGasFreeBuildings.vue
@@ -1,102 +1,20 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 
-import BuildingsTable from '~/components/BuildingsTable.vue';
-import DataDisclaimer from '~/components/DataDisclaimer.vue';
-import DataSourceFootnote from '~/components/DataSourceFootnote.vue';
-import NewTabIcon from '~/components/NewTabIcon.vue';
-
-// TODO: Figure out a way to get metaInfo working without any
-// https://github.com/xerebede/gridsome-starter-typescript/issues/37
+/**
+ * Redirect page for backwards compatibility
+ *
+ * This page was renamed to "All Electric Buildings" on Aug. 27th, 2025.
+ * This redirect ensures old bookmarks and links continue to work.
+ */
 @Component<any>({
-  components: {
-    BuildingsTable,
-    DataDisclaimer,
-    DataSourceFootnote,
-    NewTabIcon,
-  },
   metaInfo() {
-    return { title: 'Biggest Gas Free Buildings' };
+    return {
+      title: 'Redirecting to All Electric Buildings',
+      meta: [{ 'http-equiv': 'refresh', content: '0; URL=/all-electric' }],
+      link: [{ rel: 'canonical', href: '/all-electric' }],
+    };
   },
 })
-export default class TopGasUsers extends Vue {}
+export default class BiggestGasFreeBuildings extends Vue {}
 </script>
-
-<static-query>
-  query {
-    allBuilding(
-      filter: {
-        DataYear: { eq: "2023" },
-        # Use lte: 0 to capture buildings with 0, null, or empty values for gas usage
-        NaturalGasUse: { lte: 0 },
-        DistrictSteamUse: { lte: 0 },
-        # Exclude buildings that previously used gas but now report zero
-        DataAnomalies: { nin: ["gasZeroWithPreviousUse"] }
-      },
-      sortBy: "GrossFloorArea", limit: 500
-    ) {
-      edges {
-        node {
-          slugSource
-          ID
-          DataYear
-          PropertyName
-          Address
-          ZIPCode
-          path
-          GrossFloorArea
-          GrossFloorAreaRank
-          GrossFloorAreaPercentileRank
-          PrimaryPropertyType
-          GHGIntensity
-          GHGIntensityRank
-          GHGIntensityPercentileRank
-          TotalGHGEmissions
-          TotalGHGEmissionsRank
-          TotalGHGEmissionsPercentileRank
-          ElectricityUse
-          ElectricityUseRank
-          ElectricityUsePercentileRank
-          NaturalGasUse
-          NaturalGasUseRank
-          NaturalGasUsePercentileRank
-          DistrictSteamUse
-          AvgPercentileLetterGrade
-          DataAnomalies
-        }
-      }
-    }
-  }
-</static-query>
-
-<template>
-  <DefaultLayout>
-    <h1 id="main-content" tabindex="-1">
-      Chicago's {{ $static.allBuilding.edges.length }} Fully Gas Free Buildings
-    </h1>
-
-    <p class="constrained -wide">
-      These buildings are already all-electric, and feature some of the most
-      famous buildings in the city! If even the John Hancock center or Marina
-      Towers can run off of only electricity, your building can too.
-    </p>
-
-    <p class="constrained -wide">
-      <strong>Note:</strong> This list is of buildings that use neither fossil
-      gas nor a district steam system, since all district steam systems in the
-      city are currently powered by burning fossil gas (to the best of our
-      knowledge).
-    </p>
-
-    <DataDisclaimer />
-
-    <BuildingsTable
-      :buildings="$static.allBuilding.edges"
-      :show-square-footage="true"
-    />
-
-    <DataSourceFootnote />
-  </DefaultLayout>
-</template>
-
-<style lang="scss"></style>

--- a/src/pages/BiggestGasFreeBuildings.vue
+++ b/src/pages/BiggestGasFreeBuildings.vue
@@ -18,3 +18,31 @@ import { Component, Vue } from 'vue-property-decorator';
 })
 export default class BiggestGasFreeBuildings extends Vue {}
 </script>
+
+<template>
+  <DefaultLayout>
+    <div class="redirect-page">
+      <h1>Redirecting to All Electric Buildings...</h1>
+      <p>
+        This page has moved to
+        <g-link to="/all-electric">All Electric Buildings</g-link>. You will be
+        redirected automatically.
+      </p>
+    </div>
+  </DefaultLayout>
+</template>
+
+<style lang="scss" scoped>
+.redirect-page {
+  text-align: center;
+  padding: 4rem 1rem;
+
+  h1 {
+    margin-bottom: 1rem;
+  }
+
+  p {
+    margin-bottom: 0.5rem;
+  }
+}
+</style>

--- a/src/pages/blog/HowWeGradeBuildings.vue
+++ b/src/pages/blog/HowWeGradeBuildings.vue
@@ -327,6 +327,7 @@ export default class HowWeGradeBuildings extends Vue {}
           NaturalGasUse
           DistrictSteamUse
           AvgPercentileLetterGrade
+          DataAnomalies
         }
       }
     }

--- a/src/templates/BuildingDetails.vue
+++ b/src/templates/BuildingDetails.vue
@@ -136,7 +136,7 @@ query ($id: ID!, $ID: String) {
             <g-link
               v-if="fullyGasFree"
               class="pill -all-electric"
-              to="/biggest-gas-free-buildings"
+              to="/all-electric"
             >
               <span class="icon">⚡</span>
               <span class="text">All Electric</span>


### PR DESCRIPTION
# Description

I noticed the pill says "All Electric" but the page says gas free. This renames the page, so electrifychicago.net/all-electric works, and the title is clearer.

<img width="2763" height="2141" alt="image" src="https://github.com/user-attachments/assets/0c6962d6-d05c-43c6-b2f6-83ea41b9ab4f" />

Fixes # (issue)

# Testing Instructions

Please describe the tests/QA that you did to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)

## Data Update (if applicable):

- [ ] I have followed the [Data Update Checklist](DATA_UPDATE_CHECKLIST.md) for updating to new year's data

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
