### PR TITLE
Fix tooltip bug when focusing spark line

### DIFF
--- a/src/components/graphs/SparkLine.vue
+++ b/src/components/graphs/SparkLine.vue
@@ -287,7 +287,7 @@ export default class BarGraph extends Vue {
 
   focus(event: Event, datum: INumGraphPoint): void {
     this.mouseover();
-    this.mousemove(event as MouseEvent, datum);
+    this.mousemove(event, datum);
   }
 
   mouseover(): void {
@@ -303,8 +303,19 @@ export default class BarGraph extends Vue {
     );
     const scaleFactor = svgElem!.clientWidth / outerWidth;
 
-    const tooltipX = d3.pointer(event)[0] * scaleFactor + 20;
-    const tooltipY = d3.pointer(event)[1] * scaleFactor;
+    let tooltipX: number;
+    let tooltipY: number;
+    if (event instanceof MouseEvent) {
+      [tooltipX, tooltipY] = d3.pointer(event);
+    } else if (event.target instanceof SVGGraphicsElement) {
+      // This can happen for tab-focus events, where there's no pointer.
+      // In that case, use the datum's position instead of the mouse's.
+      const bbox = event.target.getBBox();
+      tooltipX = bbox.x;
+      tooltipY = bbox.y;
+    } else {
+      return;
+    }
 
     this.tooltip!.html(
       `<div class="year">${datum.x}</div>` +
@@ -313,8 +324,8 @@ export default class BarGraph extends Vue {
         `<span class="unit">${this.unit}</span>` +
         `</div>`,
     )
-      .style('left', `${tooltipX}px`)
-      .style('top', `${tooltipY}px`);
+      .style('left', `${tooltipX * scaleFactor + 20}px`)
+      .style('top', `${tooltipY * scaleFactor}px`);
   }
 
   mouseleave(): void {


### PR DESCRIPTION
# Description

https://github.com/user-attachments/assets/da38d32f-328b-43df-8b1b-cc8aa04f8aee

Tab-focusing an element triggers a mouse event.

Before this change, that didn't work because we'd try to find the cursor position, but there isn't one. (Specifically, `d3.pointer()` threw an error.)

After this change, we handle both "regular" mouse events and focus events. In the latter case, we put the tooltip next to the data point.

Fixes #246.

# Testing Instructions

Tested this by visiting a building page and using tab to focus various elements on the page. Also tried mousing over. (See attached screencast for a demo.)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~New and existing unit tests pass locally with my changes~~
- [ ] ~~If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)~~

## Data Update (if applicable):

- [ ] ~~I have followed the [Data Update Checklist](DATA_UPDATE_CHECKLIST.md) for updating to new year's data~~