### PR TITLE
210: Fix Map on Desktop Safari

### DIFF
--- a/src/pages/Map.vue
+++ b/src/pages/Map.vue
@@ -132,6 +132,7 @@ export default class MapPage extends Vue {
     this.setupMapIcons();
 
     this.map = this.Leaflet.map('buildings-map', {
+      tap: false,
       zoomDelta: this.MapConfig.ZoomDelta,
       wheelPxPerZoomLevel: this.MapConfig.WheelPxPerZoomLevel,
       zoomSnap: this.MapConfig.ZoomSnap,


### PR DESCRIPTION
# Description

Issue #210 
Map would break on desktop Safari when a marker was selected by user.

Fixes # (issue)
This was an issue with Leaflet on Safari desktop browsers.
This was solved by disabling TapHold events, which are not used in this project.
An alternate solution would be to update Leaflet to version 1.8 or later.

# Testing Instructions

Open map page and test selecting markers on different desktop and mobile browsers to ensure no unintended issues.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)

## Data Update (if applicable):

- [ ] I have followed the [Data Update Checklist](DATA_UPDATE_CHECKLIST.md) for updating to new year's data

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
