### PR TITLE
Drop global header and debugger from print mode

### DIFF
--- a/src/components/GlobalBanner.vue
+++ b/src/components/GlobalBanner.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="global-banner">
+  <!-- Make sure the banner doesn't show in printed pages, e.g. buildings -->
+  <div class="global-banner no-print">
     <div class="page-constrained">
       <div class="content-left">
         <h2>📣 Take Action to Improve Emissions Reporting!</h2>

--- a/src/components/MetaInfoPanel.vue
+++ b/src/components/MetaInfoPanel.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="meta-cont">
+  <!-- Don't print the meta panel -->
+  <div class="meta-cont no-print">
     <details class="meta-info-panel page-constrained">
       <summary class="meta-toggle-btn">
         Meta Info (Developer Only)


### PR DESCRIPTION
# Description

Fixed print mode being messed up due to adding in the global banner, so the QR code was not in the first page - a good thing to tackle in future visual testing (Issue #125).


| Before | After |
| --- | --- |
| <img width="1805" height="1745" alt="image" src="https://github.com/user-attachments/assets/c71564d3-ffaa-47c8-94ca-76a4d20ef6d1" /> | <img width="1805" height="1745" alt="Screenshot from 2025-11-18 19-41-02" src="https://github.com/user-attachments/assets/a76f8a40-c8fe-4f6d-8aa0-9b4163c3dfba" /> ||

Fixes #254


# Testing Instructions

Simple manual QA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)

## Data Update (if applicable):

- [ ] I have followed the [Data Update Checklist](DATA_UPDATE_CHECKLIST.md) for updating to new year's data

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
