### PR TITLE
Add Building Owners to Homepage

### DIFF
--- a/src/components/OwnerTile.vue
+++ b/src/components/OwnerTile.vue
@@ -1,0 +1,153 @@
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { IBuildingOwner } from '../constants/buildings-custom-info.constant.vue';
+import { IOwnerStats } from '../constants/owner-helpers.vue';
+
+/**
+ * A component that renders a tile for a building owner with key stats
+ */
+@Component
+export default class OwnerTile extends Vue {
+  @Prop({ required: true }) owner!: IBuildingOwner;
+  @Prop({ required: true }) stats!: IOwnerStats;
+}
+</script>
+
+<template>
+  <div>
+    <g-link :to="'/owner/' + owner.key + '/'" class="tile-link" tabindex="-1">
+      <div class="owner-tile">
+        <div class="logo-cont">
+          <img :src="owner.logoLarge" :alt="owner.name" />
+        </div>
+
+        <div class="main-text">
+          <g-link :to="'/owner/' + owner.key + '/'">
+            <div class="title">
+              {{ owner.name }}
+            </div>
+          </g-link>
+
+          <div class="stats">
+            <dl>
+              <div>
+                <dt>Buildings</dt>
+                <dd>
+                  <div class="value">
+                    {{ stats.buildingCount }}
+                  </div>
+                </dd>
+              </div>
+              <div>
+                <dt>Total Emissions</dt>
+                <dd>
+                  <div class="value">
+                    {{ Math.round(stats.totalGHGEmissions).toLocaleString() }}
+                  </div>
+                  <div class="unit">tons CO<sub>2</sub>e</div>
+                </dd>
+              </div>
+              <div>
+                <dt>Avg GHG Intensity</dt>
+                <dd>
+                  <div class="value">
+                    {{ stats.avgGHGIntensity.toFixed(1) }}
+                  </div>
+                  <div class="unit">kg CO<sub>2</sub> / sqft</div>
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </g-link>
+  </div>
+</template>
+
+<style lang="scss">
+.owner-tile {
+  width: 20rem; // 320px - same as BuildingTile
+  background-color: $grey-light;
+  border-radius: $brd-rad-medium;
+  overflow: hidden;
+  box-shadow: 0.125rem 0.125rem 0.75rem $box-shadow-main;
+  height: 100%;
+  transition: outline 0.3s;
+  outline: solid $border-v-thick transparent;
+  text-decoration: none;
+  color: $text-main;
+
+  &:hover,
+  &:focus-within {
+    outline: solid $border-v-thick $chicago-blue;
+  }
+
+  .logo-cont {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: $white;
+    height: 10rem; // 160px - shorter than BuildingTile
+    padding: 1.5rem;
+
+    img {
+      max-height: 100%;
+      max-width: 100%;
+      object-fit: contain;
+    }
+  }
+
+  .main-text {
+    padding: 0.75rem 1rem;
+
+    a {
+      display: block;
+      color: inherit;
+      text-decoration: none;
+
+      &:focus {
+        text-decoration: underline;
+      }
+    }
+
+    .title {
+      font-weight: bold;
+      font-size: 1.125rem;
+      line-height: 1.5;
+      margin-bottom: 0.5rem;
+    }
+
+    .stats {
+      margin-top: 0.5rem;
+    }
+
+    dl {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 0;
+
+      dt {
+        font-size: 0.75rem;
+        color: $text-mid-light;
+        font-weight: bold;
+      }
+
+      dd {
+        margin: 0;
+      }
+
+      .value {
+        font-weight: bold;
+        font-size: 1rem;
+      }
+
+      .unit {
+        font-size: 0.75rem;
+        color: $text-mid-light;
+        font-weight: bold;
+        line-height: 1;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/OwnersList.vue
+++ b/src/components/OwnersList.vue
@@ -1,0 +1,50 @@
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import OwnerTile from './OwnerTile.vue';
+import { IBuildingNode } from '../common-functions.vue';
+import {
+  calculateAllOwnerStats,
+  getTopOwnersByEmissions,
+  IOwnerWithStats,
+} from '../constants/owner-helpers.vue';
+
+/**
+ * Component that displays a list of building owners with their stats
+ */
+@Component({
+  components: {
+    OwnerTile,
+  },
+})
+export default class OwnersList extends Vue {
+  @Prop({ required: true }) buildings!: Array<IBuildingNode>;
+
+  /** Top owners to display (sorted by total emissions) */
+  topOwners: Array<IOwnerWithStats> = [];
+
+  created(): void {
+    const ownerStats = calculateAllOwnerStats(this.buildings);
+    this.topOwners = getTopOwnersByEmissions(ownerStats, 6);
+  }
+}
+</script>
+
+<template>
+  <div class="owners-list-section">
+    <div class="list-title">
+      <h2>Building Owners</h2>
+      <g-link class="bold" to="/large-owners">View All</g-link>
+    </div>
+    <p class="list-desc">
+      Explore major property owners in Chicago and their environmental impact
+    </p>
+
+    <div class="buildings-scroll-cont">
+      <ul class="building-tiles">
+        <li v-for="ownerData in topOwners" :key="ownerData.owner.key">
+          <OwnerTile :owner="ownerData.owner" :stats="ownerData.stats" />
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>

--- a/src/constants/owner-helpers.vue
+++ b/src/constants/owner-helpers.vue
@@ -1,0 +1,91 @@
+<script lang="ts">
+import {
+  BuildingOwners,
+  IBuildingOwner,
+} from './buildings-custom-info.constant.vue';
+import { IBuilding, IBuildingNode } from '../common-functions.vue';
+
+export default {};
+
+/** Stats for a single building owner */
+export interface IOwnerStats {
+  buildingCount: number;
+  totalGHGEmissions: number;
+  avgGHGIntensity: number;
+}
+
+/** Owner with calculated stats */
+export interface IOwnerWithStats {
+  owner: IBuildingOwner;
+  stats: IOwnerStats;
+}
+
+/**
+ * Calculate stats for all building owners from a list of buildings
+ * Returns a map of owner key to owner and stats
+ */
+export function calculateAllOwnerStats(
+  buildings: Array<IBuildingNode>,
+): Map<string, IOwnerWithStats> {
+  const ownerData = new Map<
+    string,
+    {
+      buildings: Array<IBuilding>;
+      totalGHGEmissions: number;
+      totalGHGIntensity: number;
+    }
+  >();
+
+  // Group buildings by owner
+  buildings.forEach((edge) => {
+    const building = edge.node;
+    const ownerKey = building.Owner;
+
+    if (ownerKey && BuildingOwners[ownerKey]) {
+      if (!ownerData.has(ownerKey)) {
+        ownerData.set(ownerKey, {
+          buildings: [],
+          totalGHGEmissions: 0,
+          totalGHGIntensity: 0,
+        });
+      }
+
+      const data = ownerData.get(ownerKey)!;
+      data.buildings.push(building);
+      data.totalGHGEmissions += building.TotalGHGEmissions || 0;
+      data.totalGHGIntensity += building.GHGIntensity || 0;
+    }
+  });
+
+  // Calculate stats for each owner
+  const ownerStats = new Map<string, IOwnerWithStats>();
+
+  ownerData.forEach((data, ownerKey) => {
+    const owner = BuildingOwners[ownerKey];
+    const buildingCount = data.buildings.length;
+
+    ownerStats.set(ownerKey, {
+      owner,
+      stats: {
+        buildingCount,
+        totalGHGEmissions: data.totalGHGEmissions,
+        avgGHGIntensity: data.totalGHGIntensity / buildingCount,
+      },
+    });
+  });
+
+  return ownerStats;
+}
+
+/**
+ * Get top N owners sorted by total emissions
+ */
+export function getTopOwnersByEmissions(
+  ownerStats: Map<string, IOwnerWithStats>,
+  limit: number = 6,
+): Array<IOwnerWithStats> {
+  return Array.from(ownerStats.values())
+    .sort((a, b) => b.stats.totalGHGEmissions - a.stats.totalGHGEmissions)
+    .slice(0, limit);
+}
+</script>

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -5,6 +5,7 @@ import { Component, Vue } from 'vue-property-decorator';
 import DataDisclaimer from '~/components/DataDisclaimer.vue';
 import DataSourceFootnote from '../components/DataSourceFootnote.vue';
 import BuildingTile from '../components/BuildingTile.vue';
+import OwnersList from '../components/OwnersList.vue';
 
 /**
  * Note: @Component<any> is required for metaInfo to work with TypeScript
@@ -17,6 +18,7 @@ import BuildingTile from '../components/BuildingTile.vue';
     BuildingTile,
     DataDisclaimer,
     DataSourceFootnote,
+    OwnersList,
   },
   metaInfo() {
     return { title: 'Home' };
@@ -94,6 +96,16 @@ export default class Index extends Vue {
           DistrictSteamUse
           AvgPercentileLetterGrade
           DataAnomalies
+        }
+      }
+    }
+    allBuildings: allBuilding {
+      edges {
+        node {
+          ID
+          Owner
+          GHGIntensity
+          TotalGHGEmissions
         }
       }
     }
@@ -178,6 +190,8 @@ export default class Index extends Vue {
             </li>
           </ul>
         </div>
+
+        <OwnersList :buildings="$page.allBuildings.edges" />
 
         <h2>Our Research &amp; Updates</h2>
 


### PR DESCRIPTION
# Description

Adds highest 6 total emission building owners to the homepage, drawing users in with something more interesting and showcasing that we have that information in a more visual way!

<img width="3028" height="2131" alt="image" src="https://github.com/user-attachments/assets/b2611b41-442b-4477-a68b-a28c543f1dd8" />

This has been sitting in the backlog for a while, so I decided to see if Claude could tackle it, and with some stewarding it did pretty great!

Fixes #160

# Testing Instructions

Manual QA

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)

## Data Update (if applicable):

- [ ] I have followed the [Data Update Checklist](DATA_UPDATE_CHECKLIST.md) for updating to new year's data

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
