### PR TITLE
Improve Search With More Fuzziness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Single source of truth for merge-gating checks. Runs locally on
+# `git commit` (after `pre-commit install`) and in CI via the
+# `Run pre-commit hooks` step in .github/workflows/linting.yml.
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -42,7 +46,7 @@ repos:
         files: "pyproject.toml|uv.lock"
       - id: typescript-format
         name: typescript-format
-        files: '\\.(js|jsx|ts|tsx|vue|css|scss|json|md)$'
+        files: "\\.(js|jsx|ts|tsx|vue|css|scss|json|md)$"
         types: [file]
         exclude: "(node_modules/.*|dist/.*|build/.*|\\.gridsome/.*|static/.*)$"
         entry: yarn prettier-fix
@@ -50,7 +54,7 @@ repos:
         pass_filenames: false
       - id: typescript-lint
         name: typescript-lint
-        files: '\\.(js|jsx|ts|tsx|vue|css|scss)$'
+        files: "\\.(js|jsx|ts|tsx|vue|css|scss)$"
         exclude: "(node_modules/.*|dist/.*|build/.*|\\.gridsome/.*|static/.*)$"
         types: [file]
         entry: yarn lint
@@ -59,7 +63,7 @@ repos:
         pass_filenames: false
       - id: typescript-typecheck
         name: typescript-typecheck
-        files: '\\.(ts|tsx|vue)$|tsconfig.*\\.json$|package\\.json$'
+        files: "\\.(ts|tsx|vue)$|tsconfig.*\\.json$|package\\.json$"
         types: [file]
         entry: npx tsc --noEmit
         require_serial: true

--- a/src/components/WardLookup.vue
+++ b/src/components/WardLookup.vue
@@ -231,7 +231,6 @@ export default class WardLookup extends Vue {
   private async loadGoogleMaps(): Promise<void> {
     // In Gridsome, client-side env vars must be prefixed with GRIDSOME_
     // Access via process.env which gets compiled at build time
-     
     const apiKey = process.env.GRIDSOME_GOOGLE_MAPS_API_KEY || '';
 
     if (!apiKey) {

--- a/src/components/WardLookup.vue
+++ b/src/components/WardLookup.vue
@@ -231,7 +231,7 @@ export default class WardLookup extends Vue {
   private async loadGoogleMaps(): Promise<void> {
     // In Gridsome, client-side env vars must be prefixed with GRIDSOME_
     // Access via process.env which gets compiled at build time
-    // eslint-disable-next-line no-undef
+     
     const apiKey = process.env.GRIDSOME_GOOGLE_MAPS_API_KEY || '';
 
     if (!apiKey) {

--- a/src/constants/building-images.constant.vue
+++ b/src/constants/building-images.constant.vue
@@ -404,34 +404,41 @@ export const BuildingImages: IBuildingImages = {
   },
   '100856': {
     imgUrl: BuildingImagesBase + 'ID-100856-united-center.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:United_Center_1.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:United_Center_1.jpg',
   },
   '103595': {
     imgUrl: BuildingImagesBase + 'ID-103595-141_West_Jackson_Boulevard.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:Chicago_Board_Of_Trade_Building.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:Chicago_Board_Of_Trade_Building.jpg',
     isTall: true,
   },
   '103669': {
     imgUrl: BuildingImagesBase + 'ID-103669-soldier-field.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:Soldier_Field_S.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:Soldier_Field_S.jpg',
   },
   '101762': {
     imgUrl: BuildingImagesBase + 'ID-101762-richard-j-daley-center.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:Daley_Center_June_20,_2025.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:Daley_Center_June_20,_2025.jpg',
   },
   '103677': {
     imgUrl: BuildingImagesBase + 'ID-103677-150_N_Riverside_Plaza.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:150_North_Riverside,_Wolf_Point,_Chicago.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:150_North_Riverside,_Wolf_Point,_Chicago.jpg',
     isTall: true,
   },
   '250129': {
     imgUrl: BuildingImagesBase + 'ID-250129-300_N_Lasalle.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:300_North_LaSalle_in_Chicago.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:300_North_LaSalle_in_Chicago.jpg',
     isTall: true,
   },
   '238910': {
     imgUrl: BuildingImagesBase + 'ID-238910-505_N_Lake_Shore_Drive.webp',
-    attributionUrl: 'https://commons.wikimedia.org/wiki/File:Lake_Point_Tower.jpg',
+    attributionUrl:
+      'https://commons.wikimedia.org/wiki/File:Lake_Point_Tower.jpg',
     isTall: true,
   },
 

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -7,7 +7,6 @@
 </static-query>
 
 <script lang="ts">
-/* global process */
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import AppFooter from '../components/layout/AppFooter.vue';
 import AppHeader from '../components/layout/AppHeader.vue';

--- a/src/pages/Admin.vue
+++ b/src/pages/Admin.vue
@@ -4,8 +4,8 @@
       <h1 id="main-content" tabindex="-1">🔧 Admin Tools</h1>
 
       <p>
-        Development-only admin interface for managing Electrify Chicago.
-        Not available in production builds.
+        Development-only admin interface for managing Electrify Chicago. Not
+        available in production builds.
       </p>
 
       <section>
@@ -84,6 +84,12 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 
+/**
+ * Note: @Component<any> is required for metaInfo to work with TypeScript
+ * This is a known limitation of vue-property-decorator + vue-meta integration
+ * See: https://github.com/xerebede/gridsome-starter-typescript/issues/37
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 @Component<any>({
   metaInfo() {
     return {
@@ -131,7 +137,8 @@ export default class Admin extends Vue {
     background-color: $grey-light;
   }
 
-  a, button {
+  a,
+  button {
     display: inline-block;
     margin-top: 1rem;
     font-weight: bold;

--- a/src/pages/BuildingImageUploader.vue
+++ b/src/pages/BuildingImageUploader.vue
@@ -257,6 +257,12 @@ interface UploadResult {
   regenSocialImgCmd?: string;
 }
 
+/**
+ * Note: @Component<any> is required for metaInfo to work with TypeScript
+ * This is a known limitation of vue-property-decorator + vue-meta integration
+ * See: https://github.com/xerebede/gridsome-starter-typescript/issues/37
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 @Component<any>({
   metaInfo() {
     return {
@@ -544,7 +550,7 @@ export default class BuildingImageUploader extends Vue {
     }
   }
 
-  input[type="file"] {
+  input[type='file'] {
     background-color: $grey;
   }
 
@@ -578,7 +584,9 @@ export default class BuildingImageUploader extends Vue {
     flex-wrap: wrap;
     gap: 1rem 0.5rem;
 
-    p { margin: 0; }
+    p {
+      margin: 0;
+    }
   }
 }
 

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -25,6 +25,66 @@ interface ISelectOption {
   value: string;
 }
 
+interface INormalizedFields {
+  name: string;
+  address: string;
+  type: string;
+}
+
+/**
+ * Word-level synonyms folded together so that "50 West Washington" matches
+ * "50 W Washington" and "Daley Street" matches "Daley St". We canonicalize
+ * to the abbreviated form because that's what the city's benchmark data uses.
+ */
+const AddressAbbreviations: Record<string, string> = {
+  // Cardinal/ordinal directions
+  north: 'n',
+  south: 's',
+  east: 'e',
+  west: 'w',
+  northeast: 'ne',
+  northwest: 'nw',
+  southeast: 'se',
+  southwest: 'sw',
+  // Street suffixes
+  street: 'st',
+  avenue: 'ave',
+  boulevard: 'blvd',
+  road: 'rd',
+  drive: 'dr',
+  lane: 'ln',
+  court: 'ct',
+  place: 'pl',
+  terrace: 'ter',
+  parkway: 'pkwy',
+  circle: 'cir',
+  square: 'sq',
+  highway: 'hwy',
+};
+
+const AddressAbbrevRegex = new RegExp(
+  `\\b(${Object.keys(AddressAbbreviations).join('|')})\\b`,
+  'g',
+);
+
+// Strip punctuation entirely so "Richard J. Daley" matches "Richard J Daley".
+const PunctuationRegex = /[.,'"`()[\]{}!?;:]/g;
+
+/**
+ * Normalize text for fuzzy substring matching: lowercase, drop punctuation,
+ * collapse address abbreviations, and squeeze whitespace.
+ */
+function normalizeForSearch(text: string): string {
+  if (!text) return '';
+
+  return text
+    .toLowerCase()
+    .replace(PunctuationRegex, ' ')
+    .replace(AddressAbbrevRegex, (match) => AddressAbbreviations[match])
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /**
  * Note: @Component<any> is required for metaInfo to work with TypeScript
  * This is a known limitation of vue-property-decorator + vue-meta integration
@@ -98,9 +158,34 @@ export default class Search extends Vue {
   /** Dropdown information on database details */
   dataDisclaimer!: HTMLDetailsElement;
 
+  /**
+   * Precomputed normalized PropertyName/Address/PrimaryPropertyType for each
+   * building edge. Built once so searches don't re-normalize ~6k records per
+   * keystroke. Keyed by edge so the table can keep using the original nodes.
+   */
+  normalizedCache: Map<IBuildingEdge, INormalizedFields> = new Map();
+
   created(): void {
+    this.buildNormalizedCache();
+
     // Make sure on load we have some data
     this.setSearchResults(this.$page.allBuilding.edges);
+  }
+
+  buildNormalizedCache(): void {
+    for (const edge of this.$page.allBuilding.edges) {
+      this.normalizedCache.set(edge, {
+        name: normalizeForSearch(edge.node.PropertyName ?? ''),
+        address: normalizeForSearch(edge.node.Address ?? ''),
+        type: normalizeForSearch(edge.node.PrimaryPropertyType ?? ''),
+      });
+    }
+  }
+
+  getNormalized(edge: IBuildingEdge): INormalizedFields {
+    return (
+      this.normalizedCache.get(edge) ?? { name: '', address: '', type: '' }
+    );
   }
 
   mounted(): void {
@@ -121,16 +206,15 @@ export default class Search extends Vue {
     this.submitSearch();
   }
 
-  searchRank(buildingEdge: IBuildingEdge, query: string): number {
+  searchRank(buildingEdge: IBuildingEdge, normalizedQuery: string): number {
+    const fields = this.getNormalized(buildingEdge);
     let matchScore = 0;
 
-    if (buildingEdge.node.PropertyName.toLowerCase().includes(query)) {
+    if (fields.name.includes(normalizedQuery)) {
       matchScore += 3;
-    } else if (buildingEdge.node.Address.toLowerCase().includes(query)) {
+    } else if (fields.address.includes(normalizedQuery)) {
       matchScore += 2;
-    } else if (
-      buildingEdge.node.PrimaryPropertyType.toLowerCase().includes(query)
-    ) {
+    } else if (fields.type.includes(normalizedQuery)) {
       matchScore += 1;
     }
 
@@ -142,12 +226,13 @@ export default class Search extends Vue {
       event.preventDefault();
     }
 
-    const query = this.searchFilter.toLowerCase().trim();
+    const rawQuery = this.searchFilter.trim();
+    const normalizedQuery = normalizeForSearch(rawQuery);
 
     const propertyFilterEncoded = encodeURIComponent(this.propertyTypeFilter);
 
-    // Update URL bar with search query so refresh persists search
-    let newUrl = `/search?${this.QueryParamKeys.search}=${query}`;
+    // Keep the URL bar showing what the user typed, not the normalized form
+    let newUrl = `/search?${this.QueryParamKeys.search}=${encodeURIComponent(rawQuery)}`;
 
     if (propertyFilterEncoded) {
       newUrl += `&${this.QueryParamKeys.propertyType}=${propertyFilterEncoded}`;
@@ -159,7 +244,7 @@ export default class Search extends Vue {
 
     // If no filters are provided, return our max number
     if (
-      !query &&
+      !normalizedQuery &&
       !this.propertyTypeFilter &&
       !this.gradeFilter &&
       !this.gradeQuintileFilter
@@ -169,22 +254,25 @@ export default class Search extends Vue {
       return;
     }
 
-    buildingsResults = buildingsResults.filter(
-      (buildingEdge: IBuildingEdge) => {
-        return (
-          buildingEdge.node.PropertyName.toLowerCase().includes(query) ||
-          buildingEdge.node.Address.toLowerCase().includes(query) ||
-          buildingEdge.node.PrimaryPropertyType.toLowerCase().includes(query)
-        );
-      },
-    );
+    if (normalizedQuery) {
+      buildingsResults = buildingsResults.filter(
+        (buildingEdge: IBuildingEdge) => {
+          const fields = this.getNormalized(buildingEdge);
+          return (
+            fields.name.includes(normalizedQuery) ||
+            fields.address.includes(normalizedQuery) ||
+            fields.type.includes(normalizedQuery)
+          );
+        },
+      );
 
-    // Sort by name matches, then address, then property type
-    buildingsResults = buildingsResults.sort(
-      (buildingEdgeA: IBuildingEdge, buildingEdgeB: IBuildingEdge) =>
-        this.searchRank(buildingEdgeB, query) -
-        this.searchRank(buildingEdgeA, query),
-    );
+      // Sort by name matches, then address, then property type
+      buildingsResults = buildingsResults.sort(
+        (buildingEdgeA: IBuildingEdge, buildingEdgeB: IBuildingEdge) =>
+          this.searchRank(buildingEdgeB, normalizedQuery) -
+          this.searchRank(buildingEdgeA, normalizedQuery),
+      );
+    }
 
     // If property type filter is specified, filter down by that
     if (this.propertyTypeFilter) {

--- a/src/pages/SocialCards.vue
+++ b/src/pages/SocialCards.vue
@@ -187,9 +187,13 @@ export default class SocialCards extends Vue {
 }
 
 .links {
-  a { display: inline-block; }
+  a {
+    display: inline-block;
+  }
 
-  a + a { margin-top: 0.5rem; }
+  a + a {
+    margin-top: 0.5rem;
+  }
 
   .grey-link {
     font-weight: bold;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "strict": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "paths": {
     "~/*": ["./src/*"],


### PR DESCRIPTION
# Description

Improves search by handling street abbreviations and punctuation, making it easier to a lot easier to find buildings. E.g. `3360 South State St` or `3360 S. State St` or `3360 South State Street` will all pull up Crown Hall (in data as `3360 S State Street`) and `Richard J Daley` will pull up `Richard J. Daley` buildings:

| Before | After |
| --- | --- |
| <img width="1054" height="333" alt="image" src="https://github.com/user-attachments/assets/d259e32b-932b-48fb-9ee5-3c2600d1338b" /> | <img width="1054" height="333" alt="image" src="https://github.com/user-attachments/assets/417b1a73-845b-4493-bd2a-184c7fe462c7" /> |
| <img width="1054" height="434" alt="image" src="https://github.com/user-attachments/assets/0f43e826-6240-4b70-9fbd-e7839c2be4e9" /> | <img width="1054" height="434" alt="image" src="https://github.com/user-attachments/assets/a085ef6f-124d-4efa-9de4-ac98eb674cbd" /> |

Fixes #294 

# Testing Instructions

Please describe the tests/QA that you did to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If I added a large new feature, I added it to the release notes (ReleaseNotes.vue)

## Data Update (if applicable):

- [ ] I have followed the [Data Update Checklist](DATA_UPDATE_CHECKLIST.md) for updating to new year's data

<!-- PR template modified from: https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ -->
