### PR TITLE
fix: use Vue tooltips for rank emojis

### DIFF
--- a/src/components/OverallRankEmoji.vue
+++ b/src/components/OverallRankEmoji.vue
@@ -3,8 +3,11 @@
     <!-- Don't show rankings if we think the data is wrong -->
     <span
       v-if="overallRank && !hasAnomalousData"
-      class="emoji overall-rank-emoji"
-      :title="overallRank.msg"
+      v-tooltip="{
+        content: overallRank.msg,
+        trigger: 'click hover',
+      }"
+      class="emoji overall-rank-emoji tooltip"
     >
       {{ overallRank.emoji }}
     </span>
@@ -12,40 +15,49 @@
     <!-- Show image emoji on tables -->
     <span
       v-if="hasBuildingImg && !largeView"
-      class="emoji has-img-emoji"
-      title="Has building photograph"
+      v-tooltip="{ content: 'Has building photograph', trigger: 'click hover' }"
+      class="emoji has-img-emoji tooltip"
     >
       📷
     </span>
 
     <span
       v-if="isGasFree && !largeView"
-      class="emoji has-img-emoji"
-      title="All Electric!"
+      v-tooltip="{ content: 'All Electric!', trigger: 'click hover' }"
+      class="emoji has-img-emoji tooltip"
     >
       ⚡
     </span>
 
     <span
       v-if="hasNeverSubmitted && !largeView"
-      class="emoji has-img-emoji"
-      title="Building Never Submitted Data"
+      v-tooltip="{
+        content: 'Building Never Submitted Data',
+        trigger: 'click hover',
+      }"
+      class="emoji has-img-emoji tooltip"
     >
       ❌
     </span>
 
     <span
       v-if="!hasNeverSubmitted && isOldData && !largeView"
-      class="emoji has-img-emoji"
-      title="Outdated data (did not submit in the latest year)"
+      v-tooltip="{
+        content: 'Outdated data (did not submit in the latest year)',
+        trigger: 'click hover',
+      }"
+      class="emoji has-img-emoji tooltip"
     >
       🕰️
     </span>
 
     <span
       v-if="hasAnomalousData && !largeView"
-      class="emoji"
-      title="Has anomalous data, likely indicating reporting errors"
+      v-tooltip="{
+        content: 'Has anomalous data, likely indicating reporting errors',
+        trigger: 'click hover',
+      }"
+      class="emoji tooltip"
     >
       ⚠️
     </span>
@@ -54,6 +66,9 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
+import vToolTip from 'v-tooltip';
+
+Vue.use(vToolTip);
 
 import {
   fullyGasFree,

--- a/src/components/OverallRankEmoji.vue
+++ b/src/components/OverallRankEmoji.vue
@@ -6,6 +6,7 @@
       v-tooltip="{
         content: overallRank.msg,
         trigger: 'click hover',
+        classes: ['tooltip', 'overall-rank-tooltip'],
       }"
       class="emoji overall-rank-emoji tooltip"
     >
@@ -15,7 +16,11 @@
     <!-- Show image emoji on tables -->
     <span
       v-if="hasBuildingImg && !largeView"
-      v-tooltip="{ content: 'Has building photograph', trigger: 'click hover' }"
+      v-tooltip="{
+        content: 'Has building photograph',
+        trigger: 'click hover',
+        classes: ['tooltip', 'overall-rank-tooltip'],
+      }"
       class="emoji has-img-emoji tooltip"
     >
       📷
@@ -23,7 +28,11 @@
 
     <span
       v-if="isGasFree && !largeView"
-      v-tooltip="{ content: 'All Electric!', trigger: 'click hover' }"
+      v-tooltip="{
+        content: 'All Electric!',
+        trigger: 'click hover',
+        classes: ['tooltip', 'overall-rank-tooltip'],
+      }"
       class="emoji has-img-emoji tooltip"
     >
       ⚡
@@ -34,6 +43,7 @@
       v-tooltip="{
         content: 'Building Never Submitted Data',
         trigger: 'click hover',
+        classes: ['tooltip', 'overall-rank-tooltip'],
       }"
       class="emoji has-img-emoji tooltip"
     >
@@ -45,6 +55,7 @@
       v-tooltip="{
         content: 'Outdated data (did not submit in the latest year)',
         trigger: 'click hover',
+        classes: ['tooltip', 'overall-rank-tooltip'],
       }"
       class="emoji has-img-emoji tooltip"
     >
@@ -56,6 +67,7 @@
       v-tooltip="{
         content: 'Has anomalous data, likely indicating reporting errors',
         trigger: 'click hover',
+        classes: ['tooltip', 'overall-rank-tooltip'],
       }"
       class="emoji tooltip"
     >
@@ -152,6 +164,14 @@ export default class OverallRankEmoji extends Vue {
     .overall-rank-emoji {
       font-size: 0.8em;
     }
+  }
+}
+
+.overall-rank-tooltip {
+  .tooltip-inner {
+    font-size: 12px;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

Replaces the native `title` attributes on the rank and status emojis with the repository's existing `v-tooltip` directive. This makes the explanations appear through the same Vue tooltip system already used by the application, instead of relying on the delayed browser tooltip.

The change stays inside `OverallRankEmoji.vue`, keeps the existing messages, and registers the existing plugin for the component.

Fixes #305

## Testing

- `corepack yarn prettier src/components/OverallRankEmoji.vue --check` passes after formatting.
- `corepack yarn eslint src/components/OverallRankEmoji.vue` passes.
- `git diff --check` passes.
- `corepack yarn build` was attempted, but did not finish within two minutes in this environment.
